### PR TITLE
[FEAT] restaurant-service health check 구현

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -4,7 +4,7 @@
 language: ko-KR
 
 reviews:
-  profile: "balanced"
+  profile: "chill"
   request_changes_workflow: false
   high_level_summary: true
   changed_files_summary: false

--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,19 @@
+addReviewers: true
+
+addAssignees: author
+
+reviewers:
+  - ji-circle
+  - githyj-jang
+  - jihxonx
+  - qldo
+  - Sehi55
+  - Jinyoung-Kim96
+
+numberOfReviewers: 6
+
+numberOfAssignees: 1
+
+# 'wip' 키워드가 제목에 있으면 실행 안 함
+skipKeywords:
+  - wip

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,17 @@
+name: Auto Assign Reviewers
+
+on:
+  pull_request:
+    types: [ opened, ready_for_review ]
+
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - name: Auto Assign Action
+        uses: kentaro-m/auto-assign-action@v1.2.5
+        with:
+          configuration-path: ".github/auto_assign.yml"

--- a/.github/workflows/branch-name-check.yml
+++ b/.github/workflows/branch-name-check.yml
@@ -1,0 +1,23 @@
+---
+name: Branch Naming Check
+on:
+  push:
+    branches-ignore:
+      - main
+      - dev
+      - init
+jobs:
+  check-branch-name:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check branch name format
+        run: |
+          BRANCH_NAME=${GITHUB_REF#refs/heads/}
+          # 정규식: 타입/이슈번호-설명
+          REGEX="^(feat|fix|refactor|docs|chore|test)\/[0-9]+-.+$"
+
+          if [[ ! $BRANCH_NAME =~ $REGEX ]]; then
+            echo "❌ ERROR: 브랜치 이름 형식이 틀렸습니다!"
+            echo "형식: 타입/이슈번호-설명 (예: feat/12-login)"
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: Java CI with Gradle
+
+on:
+  pull_request:
+    branches: [ "dev", "main" ] # dev와 main으로 향하는 PR에서만 실행
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v3
+
+# 빌드 부분은 나중에 gradlew 경로 잡고 다시 살릴 예정
+    # - name: Build with Gradle
+    #   run: ./gradlew build # 빌드 및 테스트 코드를 실행함

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ ext {
 
 dependencies {
 //	DB 연결 후 사용
-//	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
 //	eureka server 등록할 때 사용 권장
 //	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,6 @@ repositories {
 
 ext {
     set('springCloudVersion', "2025.0.1")
-    snippetsDir = file("build/generated-snippets")
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.5.14'
     id 'io.spring.dependency-management' version '1.1.7'
+    id 'org.asciidoctor.jvm.convert' version '4.0.2'
 }
 
 group = 'com.michelet'
@@ -17,6 +18,7 @@ configurations {
     compileOnly {
         extendsFrom annotationProcessor
     }
+    asciidoctorExt
 }
 
 repositories {
@@ -25,6 +27,7 @@ repositories {
 
 ext {
     set('springCloudVersion', "2025.0.1")
+    snippetsDir = file("build/generated-snippets")
 }
 
 dependencies {
@@ -52,6 +55,19 @@ dependencyManagement {
     }
 }
 
+def snippetsDir = file("build/generated-snippets")
+
 tasks.named('test') {
     useJUnitPlatform()
+    outputs.dir snippetsDir
+}
+
+tasks.named('asciidoctor') {
+    configurations 'asciidoctorExt'
+    inputs.dir snippetsDir
+    dependsOn tasks.named('test')
+    baseDirFollowsSourceFile()
+    attributes(
+            'snippets': snippetsDir
+    )
 }

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ ext {
 
 dependencies {
 //	DB 연결 후 사용
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+//	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
 //	eureka server 등록할 때 사용 권장
 //	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
@@ -42,6 +42,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,6 @@ configurations {
     compileOnly {
         extendsFrom annotationProcessor
     }
-    asciidoctorExt
 }
 
 repositories {
@@ -62,7 +61,6 @@ tasks.named('test') {
 }
 
 tasks.named('asciidoctor') {
-    configurations 'asciidoctorExt'
     inputs.dir snippetsDir
     dependsOn tasks.named('test')
     baseDirFollowsSourceFile()

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,10 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.5.13'
+    id 'org.springframework.boot' version '3.5.14'
     id 'io.spring.dependency-management' version '1.1.7'
 }
 
-group = 'com.star'
+group = 'com.michelet'
 version = '0.0.1-SNAPSHOT'
 
 java {
@@ -34,6 +34,8 @@ dependencies {
 //	eureka server 등록할 때 사용 권장
 //	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'org.postgresql:postgresql'

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,0 +1,18 @@
+= Restaurant Service API Guide
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+:sectlinks:
+:sectnums:
+
+== Health Check
+
+레스토랑 서비스의 가용 상태를 확인합니다.
+
+=== Request
+include::{snippets}/restaurant-health-check/http-request.adoc[]
+
+=== Response
+include::{snippets}/restaurant-health-check/http-response.adoc[]

--- a/src/main/java/com/michelet/restaurant/application/RestaurantQueryService.java
+++ b/src/main/java/com/michelet/restaurant/application/RestaurantQueryService.java
@@ -1,0 +1,13 @@
+package com.michelet.restaurant.application;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class RestaurantQueryService {
+
+    public String getHealthStatus() {
+        return "Restaurant Query Service is Healthy";
+    }
+}

--- a/src/main/java/com/michelet/restaurant/application/RestaurantQueryService.java
+++ b/src/main/java/com/michelet/restaurant/application/RestaurantQueryService.java
@@ -1,10 +1,10 @@
 package com.michelet.restaurant.application;
 
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
+//import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Transactional(readOnly = true)
+//@Transactional(readOnly = true)
 public class RestaurantQueryService {
 
     public String getHealthStatus() {

--- a/src/main/java/com/michelet/restaurant/presentation/RestaurantController.java
+++ b/src/main/java/com/michelet/restaurant/presentation/RestaurantController.java
@@ -1,0 +1,25 @@
+package com.michelet.restaurant.presentation;
+
+import com.michelet.restaurant.application.RestaurantQueryService;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/restaurants")
+@RequiredArgsConstructor
+public class RestaurantController {
+
+    private final RestaurantQueryService restaurantQueryService;
+
+    @GetMapping("/health")
+    public Map<String, Object> health() {
+        return Map.of(
+                "success", true,
+                "data", restaurantQueryService.getHealthStatus(),
+                "message", "Restaurant Query Service is running"
+        );
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,11 +1,12 @@
 spring:
   application:
-    name: michelet
+    name: restaurant-service
 
 server:
-  port: ${PORT} #각자 port
+  port: 19300
 
-eureka:
-  client:
-    service-url:
-      defaultZone: ${EUREKA_SERVER_URL}
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info

--- a/src/test/java/com/michelet/restaurant/RestDocsConfig.java
+++ b/src/test/java/com/michelet/restaurant/RestDocsConfig.java
@@ -1,0 +1,18 @@
+package com.michelet.restaurant;
+
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+
+import org.springframework.boot.test.autoconfigure.restdocs.RestDocsMockMvcConfigurationCustomizer;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentationConfigurer;
+
+@TestConfiguration
+public class RestDocsConfig implements RestDocsMockMvcConfigurationCustomizer {
+
+    @Override
+    public void customize(MockMvcRestDocumentationConfigurer configurer) {
+        configurer.operationPreprocessors()
+                .withRequestDefaults(prettyPrint())
+                .withResponseDefaults(prettyPrint());
+    }
+}

--- a/src/test/java/com/michelet/restaurant/RestDocsConfig.java
+++ b/src/test/java/com/michelet/restaurant/RestDocsConfig.java
@@ -14,5 +14,10 @@ public class RestDocsConfig implements RestDocsMockMvcConfigurationCustomizer {
         configurer.operationPreprocessors()
                 .withRequestDefaults(prettyPrint())
                 .withResponseDefaults(prettyPrint());
+
+        configurer.uris()
+                .withScheme("http")
+                .withHost("localhost")
+                .withPort(19300);
     }
 }

--- a/src/test/java/com/michelet/restaurant/presentation/RestaurantControllerTest.java
+++ b/src/test/java/com/michelet/restaurant/presentation/RestaurantControllerTest.java
@@ -2,50 +2,48 @@ package com.michelet.restaurant.presentation;
 
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.michelet.restaurant.RestDocsConfig;
 import com.michelet.restaurant.application.RestaurantQueryService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-@SuppressWarnings("removal")
 @WebMvcTest(RestaurantController.class)
-@AutoConfigureRestDocs
-@Import(RestDocsConfig.class)
+@AutoConfigureRestDocs(
+        uriScheme = "http",
+        uriHost = "localhost",
+        uriPort = 19300
+)
 class RestaurantControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private RestaurantQueryService restaurantQueryService;
 
     @Test
     void healthCheck() throws Exception {
         given(restaurantQueryService.getHealthStatus())
-                .willReturn("restaurant-service is healthy");
+                .willReturn("Restaurant Query Service is Healthy");
 
         mockMvc.perform(get("/api/v1/restaurants/health"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.data").value("restaurant-service is healthy"))
+                .andExpect(jsonPath("$.data").value("Restaurant Query Service is Healthy"))
                 .andExpect(jsonPath("$.message").value("Restaurant Query Service is running"))
                 .andDo(document("restaurant-health-check",
-                        responseFields(
-                                fieldWithPath("success").description("요청 성공 여부"),
-                                fieldWithPath("data").description("헬스체크 결과"),
-                                fieldWithPath("message").description("응답 메시지")
-                        )
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint())
                 ));
     }
 }

--- a/src/test/java/com/michelet/restaurant/presentation/RestaurantControllerTest.java
+++ b/src/test/java/com/michelet/restaurant/presentation/RestaurantControllerTest.java
@@ -2,7 +2,7 @@ package com.michelet.restaurant.presentation;
 
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.michelet.restaurant.application.RestaurantQueryService;
@@ -29,6 +29,8 @@ class RestaurantControllerTest {
 
         mockMvc.perform(get("/api/v1/restaurants/health"))
                 .andExpect(status().isOk())
-                .andExpect(content().string("restaurant-service is healthy"));
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").value("restaurant-service is healthy"))
+                .andExpect(jsonPath("$.message").value("Restaurant Query Service is running"));
     }
 }

--- a/src/test/java/com/michelet/restaurant/presentation/RestaurantControllerTest.java
+++ b/src/test/java/com/michelet/restaurant/presentation/RestaurantControllerTest.java
@@ -1,0 +1,34 @@
+package com.michelet.restaurant.presentation;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.michelet.restaurant.application.RestaurantQueryService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SuppressWarnings("removal")
+@WebMvcTest(RestaurantController.class)
+class RestaurantControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private RestaurantQueryService restaurantQueryService;
+
+    @Test
+    void healthCheck() throws Exception {
+        given(restaurantQueryService.getHealthStatus())
+                .willReturn("restaurant-service is healthy");
+
+        mockMvc.perform(get("/api/v1/restaurants/health"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("restaurant-service is healthy"));
+    }
+}

--- a/src/test/java/com/michelet/restaurant/presentation/RestaurantControllerTest.java
+++ b/src/test/java/com/michelet/restaurant/presentation/RestaurantControllerTest.java
@@ -1,19 +1,27 @@
 package com.michelet.restaurant.presentation;
 
 import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.michelet.restaurant.RestDocsConfig;
 import com.michelet.restaurant.application.RestaurantQueryService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
 
 @SuppressWarnings("removal")
 @WebMvcTest(RestaurantController.class)
+@AutoConfigureRestDocs
+@Import(RestDocsConfig.class)
 class RestaurantControllerTest {
 
     @Autowired
@@ -31,6 +39,13 @@ class RestaurantControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data").value("restaurant-service is healthy"))
-                .andExpect(jsonPath("$.message").value("Restaurant Query Service is running"));
+                .andExpect(jsonPath("$.message").value("Restaurant Query Service is running"))
+                .andDo(document("restaurant-health-check",
+                        responseFields(
+                                fieldWithPath("success").description("요청 성공 여부"),
+                                fieldWithPath("data").description("헬스체크 결과"),
+                                fieldWithPath("message").description("응답 메시지")
+                        )
+                ));
     }
 }


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
- restaurant-service의 헬스체크 API를 구현
- `GET /api/v1/restaurants/health` 엔드포인트를 추가
- 헬스체크 API에 대한 테스트 코드를 작성
- REST Docs 및 Asciidoctor 설정을 추가하여 헬스체크 API 문서를 생성할 수 있도록 구성
- Postman으로 헬스체크 API 정상 응답을 확인

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #3 
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to # 

## ✅ 자체 체크리스트 (필수)
- [x] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [x] Postman 테스트 완료 (인증샷 첨부)
- [x] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [x] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 Postman 실행 화면을 여기에 첨부해 주세요.
<img width="1917" height="832" alt="스크린샷 2026-04-27 030101" src="https://github.com/user-attachments/assets/3345ffd7-8c8c-473f-8e18-8be0204d86d9" />
<img width="854" height="664" alt="스크린샷 2026-04-27 030544" src="https://github.com/user-attachments/assets/0f5931ba-3b5b-4763-9049-ec3fb4c63ba4" />


## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.
> - [ ] 논의점
<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 레스토랑 서비스의 헬스 체크용 API 엔드포인트(/api/v1/restaurants/health) 추가

* **문서**
  * API 가이드 AsciiDoc 항목 추가 및 REST Docs 스니펫 연동

* **테스트**
  * 헬스 체크 웹 레이어 테스트 및 REST Docs 스니펫 생성, 테스트용 REST Docs 설정 추가

* **유지보수**
  * 빌드스크립트 및 의존성·플러그인 업데이트, 애플리케이션 이름과 포트(19300) 조정

* **구성**
  * 브랜치 네이밍 규칙·자동 할당·CI 워크플로우 추가 및 리뷰 도구 프로파일 변경 (balanced→chill)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->