### PR TITLE
[FEAT] 식당 코스 등록 API 구현

### DIFF
--- a/src/main/java/com/michelet/restaurant/application/command/CreateCourseCommand.java
+++ b/src/main/java/com/michelet/restaurant/application/command/CreateCourseCommand.java
@@ -1,0 +1,36 @@
+package com.michelet.restaurant.application.command;
+
+import com.michelet.restaurant.domain.model.CourseSessionType;
+import com.michelet.restaurant.domain.model.CourseStatus;
+import com.michelet.restaurant.presentation.dto.CreateCourseRequest;
+
+import java.util.List;
+import java.util.UUID;
+
+public record CreateCourseCommand(
+
+        UUID restaurantId,
+        String name,
+        Long price,
+        CourseSessionType sessionType,
+        CourseStatus status,
+
+        // 코스에 포함될 구조화된 메뉴 목록
+        // 서비스 계층에서 이 목록을 기반으로 menuComposition을 생성
+        List<CreateCourseMenuCommand> menus
+
+) {
+
+    public static CreateCourseCommand of(UUID restaurantId, CreateCourseRequest request) {
+        return new CreateCourseCommand(
+                restaurantId,
+                request.name(),
+                request.price(),
+                request.sessionType(),
+                request.status(),
+                request.menus().stream()
+                        .map(menu -> CreateCourseMenuCommand.from(menu))
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/com/michelet/restaurant/application/command/CreateCourseMenuCommand.java
+++ b/src/main/java/com/michelet/restaurant/application/command/CreateCourseMenuCommand.java
@@ -1,0 +1,21 @@
+package com.michelet.restaurant.application.command;
+
+import com.michelet.restaurant.domain.model.CoursePart;
+import com.michelet.restaurant.presentation.dto.CreateCourseMenuRequest;
+
+public record CreateCourseMenuCommand(
+
+        CoursePart coursePart,
+        String menuName,
+        Integer sortOrder
+
+) {
+
+    public static CreateCourseMenuCommand from(CreateCourseMenuRequest request) {
+        return new CreateCourseMenuCommand(
+                request.coursePart(),
+                request.menuName(),
+                request.sortOrder()
+        );
+    }
+}

--- a/src/main/java/com/michelet/restaurant/application/result/CourseResult.java
+++ b/src/main/java/com/michelet/restaurant/application/result/CourseResult.java
@@ -1,0 +1,20 @@
+package com.michelet.restaurant.application.result;
+
+import com.michelet.restaurant.domain.model.RestaurantCourse;
+
+import java.util.UUID;
+
+public record CourseResult(
+
+        UUID courseId,
+        UUID restaurantId
+
+) {
+
+    public static CourseResult from(RestaurantCourse course) {
+        return new CourseResult(
+                course.getCourseId(),
+                course.getRestaurantId()
+        );
+    }
+}

--- a/src/main/java/com/michelet/restaurant/application/service/command/CourseMenuCompositionGenerator.java
+++ b/src/main/java/com/michelet/restaurant/application/service/command/CourseMenuCompositionGenerator.java
@@ -1,0 +1,23 @@
+package com.michelet.restaurant.application.service.command;
+
+import com.michelet.restaurant.application.command.CreateCourseMenuCommand;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public final class CourseMenuCompositionGenerator {
+
+    private CourseMenuCompositionGenerator() {
+
+    }
+
+    public static String generate(List<CreateCourseMenuCommand> menus) {
+        return menus.stream()
+                // 사용자가 입력한 sortOrder 기준으로 메뉴 노출 순서를 확정
+                .sorted((left, right) -> Integer.compare(left.sortOrder(), right.sortOrder()))
+                // 예: 애피타이저: 제철 샐러드
+                .map(menu -> menu.coursePart().getDisplayName() + ": " + menu.menuName().trim())
+                // 예: 애피타이저: 제철 샐러드 / 메인: 양갈비
+                .collect(Collectors.joining(" / "));
+    }
+}

--- a/src/main/java/com/michelet/restaurant/application/service/command/RestaurantCourseCommandService.java
+++ b/src/main/java/com/michelet/restaurant/application/service/command/RestaurantCourseCommandService.java
@@ -1,0 +1,97 @@
+package com.michelet.restaurant.application.service.command;
+
+import com.michelet.restaurant.application.command.CreateCourseCommand;
+import com.michelet.restaurant.application.command.CreateCourseMenuCommand;
+import com.michelet.restaurant.application.result.CourseResult;
+import com.michelet.restaurant.domain.exception.CourseErrorCode;
+import com.michelet.restaurant.domain.exception.CourseException;
+import com.michelet.restaurant.domain.exception.RestaurantErrorCode;
+import com.michelet.restaurant.domain.exception.RestaurantException;
+import com.michelet.restaurant.domain.model.RestaurantCourse;
+import com.michelet.restaurant.domain.model.RestaurantCourseMenu;
+import com.michelet.restaurant.domain.repository.RestaurantCourseMenuRepository;
+import com.michelet.restaurant.domain.repository.RestaurantCourseRepository;
+import com.michelet.restaurant.domain.repository.RestaurantRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+@Service
+public class RestaurantCourseCommandService {
+
+    private final RestaurantRepository restaurantRepository;
+    private final RestaurantCourseRepository restaurantCourseRepository;
+    private final RestaurantCourseMenuRepository restaurantCourseMenuRepository;
+
+    public RestaurantCourseCommandService(RestaurantRepository restaurantRepository, RestaurantCourseRepository restaurantCourseRepository, RestaurantCourseMenuRepository restaurantCourseMenuRepository) {
+        this.restaurantRepository = restaurantRepository;
+        this.restaurantCourseRepository = restaurantCourseRepository;
+        this.restaurantCourseMenuRepository = restaurantCourseMenuRepository;
+    }
+
+    /**
+     * 식당 코스를 등록
+     *
+     * 메뉴 요약 문자열(menuComposition)은 클라이언트가 직접 보내지 않고
+     * 서버가 menus를 sortOrder 기준으로 정렬해 생성
+     */
+    @Transactional
+    public CourseResult createCourse(CreateCourseCommand command) {
+        validateRestaurantExists(command.restaurantId());
+        validateMenus(command.menus());
+
+        String menuComposition = CourseMenuCompositionGenerator.generate(command.menus());
+
+        RestaurantCourse course = RestaurantCourse.create(
+                command.restaurantId(),
+                command.name(),
+                command.price(),
+                menuComposition,
+                command.sessionType(),
+                command.status()
+        );
+
+        RestaurantCourse savedCourse = restaurantCourseRepository.save(course);
+
+        List<RestaurantCourseMenu> courseMenus = command.menus().stream()
+                .map(menu -> RestaurantCourseMenu.create(
+                        savedCourse.getCourseId(),
+                        menu.coursePart(),
+                        menu.menuName(),
+                        menu.sortOrder()
+                ))
+                .toList();
+
+        restaurantCourseMenuRepository.saveAll(courseMenus);
+
+        return CourseResult.from(savedCourse);
+    }
+
+    private void validateRestaurantExists(UUID restaurantId) {
+        restaurantRepository.findById(restaurantId)
+                .orElseThrow(() -> new RestaurantException(RestaurantErrorCode.RESTAURANT_404_NOT_FOUND));
+    }
+
+    private void validateMenus(List<CreateCourseMenuCommand> menus) {
+        if (menus == null || menus.isEmpty()) {
+            throw new CourseException(CourseErrorCode.COURSE_400_INVALID_REQUEST);
+        }
+
+        validateDuplicatedSortOrder(menus);
+    }
+
+    private void validateDuplicatedSortOrder(List<CreateCourseMenuCommand> menus) {
+        // 중복 허용 방지
+        Set<Integer> sortOrders = new HashSet<>();
+
+        for (CreateCourseMenuCommand menu : menus) {
+            if (!sortOrders.add(menu.sortOrder())) {
+                throw new CourseException(CourseErrorCode.COURSE_400_INVALID_REQUEST);
+            }
+        }
+    }
+}

--- a/src/main/java/com/michelet/restaurant/application/service/command/RestaurantCourseCommandService.java
+++ b/src/main/java/com/michelet/restaurant/application/service/command/RestaurantCourseCommandService.java
@@ -81,8 +81,18 @@ public class RestaurantCourseCommandService {
             throw new CourseException(CourseErrorCode.COURSE_400_INVALID_REQUEST);
         }
 
+        validateNullMenu(menus);
         validateDuplicatedSortOrder(menus);
     }
+
+    private void validateNullMenu(List<CreateCourseMenuCommand> menus) {
+        for (CreateCourseMenuCommand menu : menus) {
+            if (menu == null) {
+                throw new CourseException(CourseErrorCode.COURSE_400_INVALID_REQUEST);
+            }
+        }
+    }
+
 
     private void validateDuplicatedSortOrder(List<CreateCourseMenuCommand> menus) {
         // 중복 허용 방지

--- a/src/main/java/com/michelet/restaurant/domain/exception/CourseErrorCode.java
+++ b/src/main/java/com/michelet/restaurant/domain/exception/CourseErrorCode.java
@@ -1,0 +1,21 @@
+package com.michelet.restaurant.domain.exception;
+
+import com.michelet.common.exception.ErrorCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum CourseErrorCode implements ErrorCode {
+
+    COURSE_400_INVALID_REQUEST("COURSE_400_INVALID_REQUEST", "코스요청이 올바르지 않습니다.", HttpStatus.BAD_REQUEST.value());
+
+    private final String code;
+    private final String message;
+    private final int httpStatus;
+
+    CourseErrorCode(String code, String message, int httpStatus) {
+        this.code = code;
+        this.message = message;
+        this.httpStatus = httpStatus;
+    }
+}

--- a/src/main/java/com/michelet/restaurant/domain/exception/CourseException.java
+++ b/src/main/java/com/michelet/restaurant/domain/exception/CourseException.java
@@ -1,0 +1,11 @@
+package com.michelet.restaurant.domain.exception;
+
+import com.michelet.common.exception.BusinessException;
+import com.michelet.common.exception.ErrorCode;
+
+public class CourseException extends BusinessException {
+
+    public CourseException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/michelet/restaurant/domain/model/CoursePart.java
+++ b/src/main/java/com/michelet/restaurant/domain/model/CoursePart.java
@@ -1,0 +1,19 @@
+package com.michelet.restaurant.domain.model;
+
+import lombok.Getter;
+
+@Getter
+public enum CoursePart {
+
+    AMUSE_BOUCHE("아뮤즈 부쉬"),
+    APPETIZER("애피타이저"),
+    FISH("생선"),
+    MAIN("메인"),
+    DESSERT("디저트");
+
+    private final String displayName;
+
+    CoursePart(String displayName) {
+        this.displayName = displayName;
+    }
+}

--- a/src/main/java/com/michelet/restaurant/domain/model/CourseSessionType.java
+++ b/src/main/java/com/michelet/restaurant/domain/model/CourseSessionType.java
@@ -1,0 +1,6 @@
+package com.michelet.restaurant.domain.model;
+
+public enum CourseSessionType {
+    LUNCH,
+    DINNER
+}

--- a/src/main/java/com/michelet/restaurant/domain/model/CourseStatus.java
+++ b/src/main/java/com/michelet/restaurant/domain/model/CourseStatus.java
@@ -1,6 +1,6 @@
 package com.michelet.restaurant.domain.model;
 
 public enum CourseStatus {
-    ACTIVE,
-    INACTIVE
+    AVAILABLE,
+    UNAVAILABLE
 }

--- a/src/main/java/com/michelet/restaurant/domain/model/CourseStatus.java
+++ b/src/main/java/com/michelet/restaurant/domain/model/CourseStatus.java
@@ -1,0 +1,6 @@
+package com.michelet.restaurant.domain.model;
+
+public enum CourseStatus {
+    ACTIVE,
+    INACTIVE
+}

--- a/src/main/java/com/michelet/restaurant/domain/model/Restaurant.java
+++ b/src/main/java/com/michelet/restaurant/domain/model/Restaurant.java
@@ -1,28 +1,32 @@
 package com.michelet.restaurant.domain.model;
 
 import com.michelet.common.entity.BaseEntity;
-import com.michelet.restaurant.domain.model.vo.*;
-import jakarta.persistence.*;
+import com.michelet.restaurant.domain.model.vo.BusinessHours;
+import com.michelet.restaurant.domain.model.vo.ReservationOpenAt;
+import com.michelet.restaurant.domain.model.vo.RestaurantAddress;
+import com.michelet.restaurant.domain.model.vo.RestaurantName;
+import com.michelet.restaurant.domain.model.vo.RestaurantPhone;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import java.time.LocalTime;
+import java.util.UUID;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalTime;
-import java.util.Objects;
-import java.util.UUID;
 
 @Getter
 @Entity
 @Table(
         name = "p_restaurant",
         indexes = {
-                // owner 기준 식당 조회가 있을 수 있으므로 인덱스 추가
                 @Index(name = "idx_restaurant_owner_id", columnList = "owner_id"),
-
                 // 상태별 조회/필터링 대비
                 @Index(name = "idx_restaurant_status", columnList = "status"),
-
                 // 식당 이름 검색/조회 대비
                 @Index(name = "idx_restaurant_name", columnList = "name")
         }
@@ -31,7 +35,6 @@ import java.util.UUID;
 public class Restaurant extends BaseEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
     @Column(name = "restaurant_id", nullable = false, updatable = false)
     private UUID restaurantId;
 
@@ -63,7 +66,6 @@ public class Restaurant extends BaseEntity {
     @Column(name = "business_hours", nullable = false, columnDefinition = "text")
     private String businessHours;
 
-    @Builder(access = AccessLevel.PRIVATE)
     private Restaurant(
             UUID ownerId,
             String name,
@@ -75,14 +77,15 @@ public class Restaurant extends BaseEntity {
             RestaurantStatus status,
             String businessHours
     ) {
-        this.ownerId = Objects.requireNonNull(ownerId, "ownerId must not be null");
+        this.restaurantId = UUID.randomUUID();
+        this.ownerId = validateOwnerId(ownerId);
         this.name = RestaurantName.of(name).value();
         this.address = RestaurantAddress.of(address).value();
         this.phone = RestaurantPhone.of(phone).value();
         this.description = normalizeDescription(description);
         this.reservationOpenAt = ReservationOpenAt.of(reservationOpenAt).value();
         this.avgMealDurationMin = validateAvgMealDuration(avgMealDurationMin);
-        this.status = Objects.requireNonNull(status, "status must not be null");
+        this.status = validateStatus(status);
         this.businessHours = BusinessHours.of(businessHours).value();
     }
 
@@ -97,19 +100,18 @@ public class Restaurant extends BaseEntity {
             RestaurantStatus status,
             String businessHours
     ) {
-        return Restaurant.builder()
-                .ownerId(ownerId)
-                .name(name)
-                .address(address)
-                .phone(phone)
-                .description(description)
-                .reservationOpenAt(reservationOpenAt)
-                .avgMealDurationMin(avgMealDurationMin)
-                .status(status)
-                .businessHours(businessHours)
-                .build();
+        return new Restaurant(
+                ownerId,
+                name,
+                address,
+                phone,
+                description,
+                reservationOpenAt,
+                avgMealDurationMin,
+                status,
+                businessHours
+        );
     }
-
 
     public void updateBasicInfo(
             String name,
@@ -127,14 +129,17 @@ public class Restaurant extends BaseEntity {
         this.description = normalizeDescription(description);
         this.reservationOpenAt = ReservationOpenAt.of(reservationOpenAt).value();
         this.avgMealDurationMin = validateAvgMealDuration(avgMealDurationMin);
-        this.status = Objects.requireNonNull(status, "status must not be null");
+        this.status = validateStatus(status);
         this.businessHours = BusinessHours.of(businessHours).value();
     }
 
-    /**
-     * 평균 식사 시간 검증
-     * 0 이하 값은 비정상 데이터로 간주한다.
-     */
+    private UUID validateOwnerId(UUID ownerId) {
+        if (ownerId == null) {
+            throw new IllegalArgumentException("오너 ID는 필수입니다.");
+        }
+        return ownerId;
+    }
+
     private Integer validateAvgMealDuration(Integer avgMealDurationMin) {
         if (avgMealDurationMin == null || avgMealDurationMin <= 0) {
             throw new IllegalArgumentException("평균 식사 시간은 1분 이상이어야 합니다.");
@@ -142,10 +147,13 @@ public class Restaurant extends BaseEntity {
         return avgMealDurationMin;
     }
 
-    /**
-     * description은 null 허용.
-     * 공백만 들어온 경우는 null로 정규화한다.
-     */
+    private RestaurantStatus validateStatus(RestaurantStatus status) {
+        if (status == null) {
+            throw new IllegalArgumentException("식당 상태는 필수입니다.");
+        }
+        return status;
+    }
+
     private String normalizeDescription(String description) {
         if (description == null) {
             return null;

--- a/src/main/java/com/michelet/restaurant/domain/model/RestaurantCourse.java
+++ b/src/main/java/com/michelet/restaurant/domain/model/RestaurantCourse.java
@@ -1,0 +1,136 @@
+package com.michelet.restaurant.domain.model;
+
+import com.michelet.common.entity.BaseEntity;
+import jakarta.persistence.*;
+
+import java.util.UUID;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(
+        name = "p_restaurant_course",
+        indexes = {
+                @Index(name = "idx_restaurant_course_restaurant_id", columnList = "restaurant_id"),
+                @Index(name = "idx_restaurant_course_status", columnList = "status")
+        }
+)
+@Access(AccessType.FIELD)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RestaurantCourse extends BaseEntity {
+
+    @Id
+    @Column(name = "course_id", nullable = false, updatable = false)
+    private UUID courseId;
+
+    @Column(name = "restaurant_id", nullable = false)
+    private UUID restaurantId;
+
+    @Column(name = "name", nullable = false, length = 100)
+    private String name;
+
+    @Column(name = "price", nullable = false)
+    private Long price;
+
+    @Column(name = "menu_composition", nullable = false, columnDefinition = "text")
+    private String menuComposition;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "session_type", nullable = false, length = 20)
+    private CourseSessionType sessionType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 30)
+    private CourseStatus status;
+
+    private RestaurantCourse(
+            UUID restaurantId,
+            String name,
+            Long price,
+            String menuComposition,
+            CourseSessionType sessionType,
+            CourseStatus status
+    ) {
+        this.courseId = UUID.randomUUID();
+        this.restaurantId = validateRestaurantId(restaurantId);
+        this.name = validateName(name);
+        this.price = validatePrice(price);
+        this.menuComposition = validateMenuComposition(menuComposition);
+        this.sessionType = validateSessionType(sessionType);
+        this.status = validateStatus(status);
+    }
+
+    /**
+     * 식당 코스를 생성
+     *
+     * courseId는 애플리케이션에서 UUID를 직접 생성
+     * menuComposition은 서비스 계층에서 menus[] 기반으로 생성한 값을 전달
+     */
+    public static RestaurantCourse create(
+            UUID restaurantId,
+            String name,
+            Long price,
+            String menuComposition,
+            CourseSessionType sessionType,
+            CourseStatus status
+    ) {
+        return new RestaurantCourse(
+                restaurantId,
+                name,
+                price,
+                menuComposition,
+                sessionType,
+                status
+        );
+    }
+
+    private UUID validateRestaurantId(UUID restaurantId) {
+        if (restaurantId == null) {
+            throw new IllegalArgumentException("식당 ID는 필수입니다.");
+        }
+        return restaurantId;
+    }
+
+    private String validateName(String name) {
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("코스 이름은 필수입니다.");
+        }
+
+        String normalized = name.trim();
+        if (normalized.length() > 100) {
+            throw new IllegalArgumentException("코스 이름은 100자를 초과할 수 없습니다.");
+        }
+        return normalized;
+    }
+
+    private Long validatePrice(Long price) {
+        if (price == null || price <= 0L) {
+            throw new IllegalArgumentException("코스 가격은 1 이상이어야 합니다.");
+        }
+        return price;
+    }
+
+    private String validateMenuComposition(String menuComposition) {
+        if (menuComposition == null || menuComposition.isBlank()) {
+            throw new IllegalArgumentException("코스 메뉴 구성 정보는 필수입니다.");
+        }
+        return menuComposition.trim();
+    }
+
+    private CourseSessionType validateSessionType(CourseSessionType sessionType) {
+        if (sessionType == null) {
+            throw new IllegalArgumentException("코스 세션 타입은 필수입니다.");
+        }
+        return sessionType;
+    }
+
+    private CourseStatus validateStatus(CourseStatus status) {
+        if (status == null) {
+            throw new IllegalArgumentException("코스 상태는 필수입니다.");
+        }
+        return status;
+    }
+}

--- a/src/main/java/com/michelet/restaurant/domain/model/RestaurantCourseMenu.java
+++ b/src/main/java/com/michelet/restaurant/domain/model/RestaurantCourseMenu.java
@@ -1,0 +1,106 @@
+package com.michelet.restaurant.domain.model;
+
+import com.michelet.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@Entity
+@Table(
+        name = "p_restaurant_course_menu",
+        indexes = {
+                @Index(name = "idx_course_menu_course_id_sort_order", columnList = "course_id, sort_order")
+        },
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_restaurant_course_menu_course_id_sort_order",
+                        columnNames = {"course_id", "sort_order"}
+                )
+        }
+)
+@Access(AccessType.FIELD)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RestaurantCourseMenu extends BaseEntity {
+
+    @Id
+    @Column(name = "course_menu_id", nullable = false, updatable = false)
+    private UUID courseMenuId;
+
+    @Column(name = "course_id", nullable = false)
+    private UUID courseId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "course_part", nullable = false, length = 30)
+    private CoursePart coursePart;
+
+    @Column(name = "menu_name", nullable = false, length = 100)
+    private String menuName;
+
+    @Column(name = "sort_order", nullable = false)
+    private Integer sortOrder;
+
+    private RestaurantCourseMenu(
+            UUID courseId,
+            CoursePart coursePart,
+            String menuName,
+            Integer sortOrder
+    ) {
+        this.courseMenuId = UUID.randomUUID();
+        this.courseId = validateCourseId(courseId);
+        this.coursePart = validateCoursePart(coursePart);
+        this.menuName = validateMenuName(menuName);
+        this.sortOrder = validateSortOrder(sortOrder);
+    }
+
+    public static RestaurantCourseMenu create(
+            UUID courseId,
+            CoursePart coursePart,
+            String menuName,
+            Integer sortOrder
+    ) {
+        return new RestaurantCourseMenu(
+                courseId,
+                coursePart,
+                menuName,
+                sortOrder);
+    }
+
+    private UUID validateCourseId(UUID courseId) {
+        if (courseId == null) {
+            throw new IllegalArgumentException("코스 ID는 필수입니다.");
+        }
+        return courseId;
+    }
+
+    private CoursePart validateCoursePart(CoursePart coursePart) {
+        if (coursePart == null) {
+            throw new IllegalArgumentException("코스 메뉴 파트는 필수입니다.");
+        }
+        return coursePart;
+    }
+
+    private String validateMenuName(String menuName) {
+        if (menuName == null || menuName.isBlank()) {
+            throw new IllegalArgumentException("코스 메뉴 이름은 필수입니다.");
+        }
+
+        String normalized = menuName.trim();
+        if (normalized.length() > 100) {
+            throw new IllegalArgumentException("코스 메뉴 이름은 100자를 초과할 수 없습니다.");
+        }
+
+        return normalized;
+    }
+
+
+    private Integer validateSortOrder(Integer sortOrder) {
+        if (sortOrder == null || sortOrder <= 0) {
+            throw new IllegalArgumentException("코스 메뉴 순서는 1 이상이어야 합니다.");
+        }
+        return sortOrder;
+    }
+}

--- a/src/main/java/com/michelet/restaurant/domain/repository/RestaurantCourseMenuRepository.java
+++ b/src/main/java/com/michelet/restaurant/domain/repository/RestaurantCourseMenuRepository.java
@@ -1,0 +1,11 @@
+package com.michelet.restaurant.domain.repository;
+
+import com.michelet.restaurant.domain.model.RestaurantCourseMenu;
+
+import java.util.List;
+
+public interface RestaurantCourseMenuRepository {
+
+    // 코스에 포함된 메뉴 목록을 한 번에 저장
+    List<RestaurantCourseMenu> saveAll(List<RestaurantCourseMenu> restaurantCourseMenus);
+}

--- a/src/main/java/com/michelet/restaurant/domain/repository/RestaurantCourseRepository.java
+++ b/src/main/java/com/michelet/restaurant/domain/repository/RestaurantCourseRepository.java
@@ -1,0 +1,10 @@
+package com.michelet.restaurant.domain.repository;
+
+import com.michelet.restaurant.domain.model.RestaurantCourse;
+
+public interface RestaurantCourseRepository {
+
+    // 코스 엔티티를 저장
+    // 실제 저장 방식은 infrastructure 계층의 JpaRepository 구현체에 위임
+    RestaurantCourse save(RestaurantCourse restaurantCourse);
+}

--- a/src/main/java/com/michelet/restaurant/infrastructure/persistence/RestaurantCourseJpaRepository.java
+++ b/src/main/java/com/michelet/restaurant/infrastructure/persistence/RestaurantCourseJpaRepository.java
@@ -1,0 +1,13 @@
+package com.michelet.restaurant.infrastructure.persistence;
+
+import com.michelet.restaurant.domain.model.RestaurantCourse;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface RestaurantCourseJpaRepository extends JpaRepository<RestaurantCourse, UUID> {
+
+    // 현재 Issue #11 범위는 코스 등록
+    // 등록에는 JpaRepository 기본 save 메서드만 필요하므로 별도 조회 메서드는 추가x
+
+}

--- a/src/main/java/com/michelet/restaurant/infrastructure/persistence/RestaurantCourseMenuJpaRepository.java
+++ b/src/main/java/com/michelet/restaurant/infrastructure/persistence/RestaurantCourseMenuJpaRepository.java
@@ -1,4 +1,4 @@
-package com.michelet.restaurant.infrastructure.persistence.query;
+package com.michelet.restaurant.infrastructure.persistence;
 
 import com.michelet.restaurant.domain.model.RestaurantCourseMenu;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/michelet/restaurant/infrastructure/persistence/RestaurantCourseMenuRepositoryImpl.java
+++ b/src/main/java/com/michelet/restaurant/infrastructure/persistence/RestaurantCourseMenuRepositoryImpl.java
@@ -1,0 +1,22 @@
+package com.michelet.restaurant.infrastructure.persistence;
+
+import com.michelet.restaurant.domain.model.RestaurantCourseMenu;
+import com.michelet.restaurant.domain.repository.RestaurantCourseMenuRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public class RestaurantCourseMenuRepositoryImpl implements RestaurantCourseMenuRepository {
+
+    private final RestaurantCourseMenuJpaRepository restaurantCourseMenuJpaRepository;
+
+    public RestaurantCourseMenuRepositoryImpl(RestaurantCourseMenuJpaRepository restaurantCourseMenuJpaRepository) {
+        this.restaurantCourseMenuJpaRepository = restaurantCourseMenuJpaRepository;
+    }
+
+    @Override
+    public List<RestaurantCourseMenu> saveAll(List<RestaurantCourseMenu> restaurantCourseMenus) {
+        return restaurantCourseMenuJpaRepository.saveAll(restaurantCourseMenus);
+    }
+}

--- a/src/main/java/com/michelet/restaurant/infrastructure/persistence/RestaurantCourseRepositoryImpl.java
+++ b/src/main/java/com/michelet/restaurant/infrastructure/persistence/RestaurantCourseRepositoryImpl.java
@@ -1,0 +1,20 @@
+package com.michelet.restaurant.infrastructure.persistence;
+
+import com.michelet.restaurant.domain.model.RestaurantCourse;
+import com.michelet.restaurant.domain.repository.RestaurantCourseRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class RestaurantCourseRepositoryImpl implements RestaurantCourseRepository {
+
+    private final RestaurantCourseJpaRepository restaurantCourseJpaRepository;
+
+    public RestaurantCourseRepositoryImpl(RestaurantCourseJpaRepository restaurantCourseJpaRepository) {
+        this.restaurantCourseJpaRepository = restaurantCourseJpaRepository;
+    }
+
+    @Override
+    public RestaurantCourse save(RestaurantCourse restaurantCourse) {
+        return restaurantCourseJpaRepository.save(restaurantCourse);
+    }
+}

--- a/src/main/java/com/michelet/restaurant/infrastructure/persistence/query/RestaurantCourseMenuJpaRepository.java
+++ b/src/main/java/com/michelet/restaurant/infrastructure/persistence/query/RestaurantCourseMenuJpaRepository.java
@@ -1,0 +1,13 @@
+package com.michelet.restaurant.infrastructure.persistence.query;
+
+import com.michelet.restaurant.domain.model.RestaurantCourseMenu;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface RestaurantCourseMenuJpaRepository extends JpaRepository<RestaurantCourseMenu, UUID> {
+
+    // 현재 Issue #11 범위는 코스 등록
+    // 등록에는 JpaRepository 기본 saveAll 메서드만 필요하므로 별도 조회 메서드는 추가x
+
+}

--- a/src/main/java/com/michelet/restaurant/presentation/controller/external/RestaurantCourseController.java
+++ b/src/main/java/com/michelet/restaurant/presentation/controller/external/RestaurantCourseController.java
@@ -1,0 +1,38 @@
+package com.michelet.restaurant.presentation.controller.external;
+
+import com.michelet.common.response.ApiResponse;
+import com.michelet.restaurant.application.command.CreateCourseCommand;
+import com.michelet.restaurant.application.result.CourseResult;
+import com.michelet.restaurant.application.service.command.RestaurantCourseCommandService;
+import com.michelet.restaurant.presentation.dto.CourseResponse;
+import com.michelet.restaurant.presentation.dto.CreateCourseRequest;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/restaurants/{restaurantId}/courses")
+public class RestaurantCourseController {
+
+    private final RestaurantCourseCommandService restaurantCourseCommandService;
+
+    public RestaurantCourseController(RestaurantCourseCommandService restaurantCourseCommandService) {
+        this.restaurantCourseCommandService = restaurantCourseCommandService;
+    }
+
+    @PostMapping
+    public ApiResponse<CourseResponse> createCourse(@PathVariable UUID restaurantId,
+                                                    @Valid @RequestBody CreateCourseRequest request) {
+
+        CreateCourseCommand command = CreateCourseCommand.of(restaurantId, request);
+        CourseResult result = restaurantCourseCommandService.createCourse(command);
+
+        return ApiResponse.ok(
+                CourseResponse.of(
+                        result.courseId(),
+                        result.restaurantId()
+                )
+        );
+    }
+}

--- a/src/main/java/com/michelet/restaurant/presentation/dto/CourseResponse.java
+++ b/src/main/java/com/michelet/restaurant/presentation/dto/CourseResponse.java
@@ -1,0 +1,14 @@
+package com.michelet.restaurant.presentation.dto;
+
+import java.util.UUID;
+
+public record CourseResponse(
+
+        UUID courseId,
+        UUID restaurantId
+) {
+
+    public static CourseResponse of(UUID courseId, UUID restaurantId) {
+        return new CourseResponse(courseId, restaurantId);
+    }
+}

--- a/src/main/java/com/michelet/restaurant/presentation/dto/CreateCourseMenuRequest.java
+++ b/src/main/java/com/michelet/restaurant/presentation/dto/CreateCourseMenuRequest.java
@@ -1,0 +1,27 @@
+package com.michelet.restaurant.presentation.dto;
+
+import com.michelet.restaurant.domain.model.CoursePart;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record CreateCourseMenuRequest(
+
+        // 코스 메뉴가 어느 파트에 속하는지 나타냄(AMUSE_BOUCHE, APPETIZER, FISH, MAIN, DESSERT)
+        @NotNull(message = "코스 파트는 필수입니다.")
+        CoursePart coursePart,
+
+        // 사용자에게 노출될 개별 메뉴명
+        @NotNull(message = "메뉴명은 필수입니다.")
+        @Size(max = 100, message = "메뉴명은 100자를 초과할 수 없습니다.")
+        String menuName,
+
+        // 한 코스 안에서 메뉴가 노출되는 순서다.
+        // 서버는 이 값을 기준으로 menuComposition을 생성
+        @NotNull(message = "정렬 순서는 필수입니다.")
+        @Min(value = 1, message = "정렬 순서는 1 이상이어야 합니다.")
+        Integer sortOrder
+
+
+) {
+}

--- a/src/main/java/com/michelet/restaurant/presentation/dto/CreateCourseMenuRequest.java
+++ b/src/main/java/com/michelet/restaurant/presentation/dto/CreateCourseMenuRequest.java
@@ -2,6 +2,7 @@ package com.michelet.restaurant.presentation.dto;
 
 import com.michelet.restaurant.domain.model.CoursePart;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
@@ -12,7 +13,8 @@ public record CreateCourseMenuRequest(
         CoursePart coursePart,
 
         // 사용자에게 노출될 개별 메뉴명
-        @NotNull(message = "메뉴명은 필수입니다.")
+        // null, 빈 문자열, 공백 문자열방지
+        @NotBlank(message = "메뉴명은 필수입니다.")
         @Size(max = 100, message = "메뉴명은 100자를 초과할 수 없습니다.")
         String menuName,
 

--- a/src/main/java/com/michelet/restaurant/presentation/dto/CreateCourseMenuRequest.java
+++ b/src/main/java/com/michelet/restaurant/presentation/dto/CreateCourseMenuRequest.java
@@ -16,7 +16,7 @@ public record CreateCourseMenuRequest(
         @Size(max = 100, message = "메뉴명은 100자를 초과할 수 없습니다.")
         String menuName,
 
-        // 한 코스 안에서 메뉴가 노출되는 순서다.
+        // 한 코스 안에서 메뉴가 노출되는 순서
         // 서버는 이 값을 기준으로 menuComposition을 생성
         @NotNull(message = "정렬 순서는 필수입니다.")
         @Min(value = 1, message = "정렬 순서는 1 이상이어야 합니다.")

--- a/src/main/java/com/michelet/restaurant/presentation/dto/CreateCourseRequest.java
+++ b/src/main/java/com/michelet/restaurant/presentation/dto/CreateCourseRequest.java
@@ -29,7 +29,7 @@ public record CreateCourseRequest(
         // 클라이언트는 menuComposition을 직접 보내지 않고, 서버가 menus를 기반으로 생성
         @Valid
         @NotEmpty(message = "코스 메뉴는 1개 이상 필요합니다.")
-        List<CreateCourseRequest> menus
+        List<CreateCourseMenuRequest> menus
 
 ) {
 }

--- a/src/main/java/com/michelet/restaurant/presentation/dto/CreateCourseRequest.java
+++ b/src/main/java/com/michelet/restaurant/presentation/dto/CreateCourseRequest.java
@@ -1,0 +1,35 @@
+package com.michelet.restaurant.presentation.dto;
+
+import com.michelet.restaurant.domain.model.CourseSessionType;
+import com.michelet.restaurant.domain.model.CourseStatus;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+
+import java.util.List;
+
+public record CreateCourseRequest(
+
+        @NotBlank(message = "코스명은 필수입니다.")
+        @Size(max = 100, message = "코스명은 100자를 초과할 수 없습니다.")
+        String name,
+
+        @NotNull(message = "코스 가격은 필수입니다.")
+        @Min(value = 1, message = "코스 가격은 1 이상이어야 합니다.")
+        Long price,
+
+        // 런치/디너 등 코스가 제공되는 세션 타입
+        @NotNull(message = "코스 세션 타입은 필수입니다.")
+        CourseSessionType sessionType,
+
+        // 코스 판매 가능 상태
+        @NotNull(message = "코스 상태는 필수입니다.")
+        CourseStatus status,
+
+        // 코스의 구조화된 메뉴 목록
+        // 클라이언트는 menuComposition을 직접 보내지 않고, 서버가 menus를 기반으로 생성
+        @Valid
+        @NotEmpty(message = "코스 메뉴는 1개 이상 필요합니다.")
+        List<CreateCourseRequest> menus
+
+) {
+}

--- a/src/main/java/com/michelet/restaurant/presentation/dto/CreateCourseRequest.java
+++ b/src/main/java/com/michelet/restaurant/presentation/dto/CreateCourseRequest.java
@@ -29,7 +29,7 @@ public record CreateCourseRequest(
         // 클라이언트는 menuComposition을 직접 보내지 않고, 서버가 menus를 기반으로 생성
         @Valid
         @NotEmpty(message = "코스 메뉴는 1개 이상 필요합니다.")
-        List<CreateCourseMenuRequest> menus
+        List<@NotNull(message = "코스 메뉴 항목은 필수입니다.") @Valid CreateCourseMenuRequest> menus
 
 ) {
 }

--- a/src/test/java/com/michelet/restaurant/application/service/command/RestaurantCourseCommandServiceTest.java
+++ b/src/test/java/com/michelet/restaurant/application/service/command/RestaurantCourseCommandServiceTest.java
@@ -25,6 +25,7 @@ import com.michelet.restaurant.domain.repository.RestaurantCourseMenuRepository;
 import com.michelet.restaurant.domain.repository.RestaurantCourseRepository;
 import com.michelet.restaurant.domain.repository.RestaurantRepository;
 import java.time.LocalTime;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -195,6 +196,37 @@ class RestaurantCourseCommandServiceTest {
         then(restaurantCourseRepository).should(never()).save(any(RestaurantCourse.class));
         then(restaurantCourseMenuRepository).should(never()).saveAll(anyList());
     }
+
+    @Test
+    @DisplayName("코스 메뉴 항목이 null이면 예외 발생")
+    void 코스메뉴항목이null이면_예외발생() {
+        UUID restaurantId = UUID.randomUUID();
+        Restaurant restaurant = createRestaurant();
+
+        CreateCourseCommand command = new CreateCourseCommand(
+                restaurantId,
+                "Dinner Course",
+                150000L,
+                CourseSessionType.DINNER,
+                CourseStatus.AVAILABLE,
+                Collections.singletonList(null)
+        );
+
+        given(restaurantRepository.findById(restaurantId))
+                .willReturn(Optional.of(restaurant));
+
+        CourseException exception = assertThrows(
+                CourseException.class,
+                () -> restaurantCourseCommandService.createCourse(command)
+        );
+
+        assertThat(exception.getErrorCode())
+                .isEqualTo(CourseErrorCode.COURSE_400_INVALID_REQUEST.getCode());
+
+        then(restaurantCourseRepository).should(never()).save(any(RestaurantCourse.class));
+        then(restaurantCourseMenuRepository).should(never()).saveAll(anyList());
+    }
+
 
     private Restaurant createRestaurant() {
         return Restaurant.create(

--- a/src/test/java/com/michelet/restaurant/application/service/command/RestaurantCourseCommandServiceTest.java
+++ b/src/test/java/com/michelet/restaurant/application/service/command/RestaurantCourseCommandServiceTest.java
@@ -1,0 +1,212 @@
+package com.michelet.restaurant.application.service.command;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import com.michelet.restaurant.application.command.CreateCourseCommand;
+import com.michelet.restaurant.application.command.CreateCourseMenuCommand;
+import com.michelet.restaurant.application.result.CourseResult;
+import com.michelet.restaurant.domain.exception.CourseErrorCode;
+import com.michelet.restaurant.domain.exception.CourseException;
+import com.michelet.restaurant.domain.exception.RestaurantException;
+import com.michelet.restaurant.domain.model.CoursePart;
+import com.michelet.restaurant.domain.model.CourseSessionType;
+import com.michelet.restaurant.domain.model.CourseStatus;
+import com.michelet.restaurant.domain.model.Restaurant;
+import com.michelet.restaurant.domain.model.RestaurantCourse;
+import com.michelet.restaurant.domain.model.RestaurantCourseMenu;
+import com.michelet.restaurant.domain.model.RestaurantStatus;
+import com.michelet.restaurant.domain.repository.RestaurantCourseMenuRepository;
+import com.michelet.restaurant.domain.repository.RestaurantCourseRepository;
+import com.michelet.restaurant.domain.repository.RestaurantRepository;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RestaurantCourseCommandServiceTest {
+
+    @InjectMocks
+    private RestaurantCourseCommandService restaurantCourseCommandService;
+
+    @Mock
+    private RestaurantRepository restaurantRepository;
+
+    @Mock
+    private RestaurantCourseRepository restaurantCourseRepository;
+
+    @Mock
+    private RestaurantCourseMenuRepository restaurantCourseMenuRepository;
+
+    @Test
+    @DisplayName("코스 등록")
+    void 코스등록() {
+        UUID restaurantId = UUID.randomUUID();
+        Restaurant restaurant = createRestaurant();
+
+        CreateCourseCommand command = new CreateCourseCommand(
+                restaurantId,
+                "Dinner Course",
+                150000L,
+                CourseSessionType.DINNER,
+                CourseStatus.AVAILABLE,
+                List.of(
+                        new CreateCourseMenuCommand(
+                                CoursePart.MAIN,
+                                "양갈비",
+                                2
+                        ),
+                        new CreateCourseMenuCommand(
+                                CoursePart.APPETIZER,
+                                "제철 샐러드",
+                                1
+                        )
+                )
+        );
+
+        given(restaurantRepository.findById(restaurantId))
+                .willReturn(Optional.of(restaurant));
+
+        given(restaurantCourseRepository.save(any(RestaurantCourse.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+        given(restaurantCourseMenuRepository.saveAll(anyList()))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+        CourseResult result = restaurantCourseCommandService.createCourse(command);
+
+        ArgumentCaptor<RestaurantCourse> courseCaptor = ArgumentCaptor.forClass(RestaurantCourse.class);
+        then(restaurantCourseRepository).should().save(courseCaptor.capture());
+
+        RestaurantCourse savedCourse = courseCaptor.getValue();
+
+        assertThat(result.courseId()).isEqualTo(savedCourse.getCourseId());
+        assertThat(result.restaurantId()).isEqualTo(restaurantId);
+
+        assertThat(savedCourse.getRestaurantId()).isEqualTo(restaurantId);
+        assertThat(savedCourse.getName()).isEqualTo("Dinner Course");
+        assertThat(savedCourse.getPrice()).isEqualTo(150000L);
+        assertThat(savedCourse.getSessionType()).isEqualTo(CourseSessionType.DINNER);
+        assertThat(savedCourse.getStatus()).isEqualTo(CourseStatus.AVAILABLE);
+        assertThat(savedCourse.getMenuComposition())
+                .isEqualTo("애피타이저: 제철 샐러드 / 메인: 양갈비");
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<RestaurantCourseMenu>> courseMenusCaptor =
+                ArgumentCaptor.forClass(List.class);
+
+        then(restaurantCourseMenuRepository).should().saveAll(courseMenusCaptor.capture());
+
+        List<RestaurantCourseMenu> savedCourseMenus = courseMenusCaptor.getValue();
+
+        assertThat(savedCourseMenus).hasSize(2);
+        assertThat(savedCourseMenus)
+                .extracting(RestaurantCourseMenu::getCourseId)
+                .containsOnly(savedCourse.getCourseId());
+        assertThat(savedCourseMenus)
+                .extracting(RestaurantCourseMenu::getSortOrder)
+                .containsExactlyInAnyOrder(1, 2);
+    }
+
+    @Test
+    @DisplayName("없는 식당이면 예외 발생")
+    void 없는식당이면_예외발생() {
+        UUID restaurantId = UUID.randomUUID();
+
+        CreateCourseCommand command = new CreateCourseCommand(
+                restaurantId,
+                "Dinner Course",
+                150000L,
+                CourseSessionType.DINNER,
+                CourseStatus.AVAILABLE,
+                List.of(
+                        new CreateCourseMenuCommand(
+                                CoursePart.APPETIZER,
+                                "제철 샐러드",
+                                1
+                        )
+                )
+        );
+
+        given(restaurantRepository.findById(restaurantId))
+                .willReturn(Optional.empty());
+
+        RestaurantException exception = assertThrows(
+                RestaurantException.class,
+                () -> restaurantCourseCommandService.createCourse(command)
+        );
+
+        assertThat(exception.getErrorCode()).isEqualTo("RESTAURANT_404_NOT_FOUND");
+
+        then(restaurantCourseRepository).should(never()).save(any(RestaurantCourse.class));
+        then(restaurantCourseMenuRepository).should(never()).saveAll(anyList());
+    }
+
+    @Test
+    @DisplayName("정렬 순서가 중복되면 예외 발생")
+    void 정렬순서가중복되면_예외발생() {
+        UUID restaurantId = UUID.randomUUID();
+        Restaurant restaurant = createRestaurant();
+
+        CreateCourseCommand command = new CreateCourseCommand(
+                restaurantId,
+                "Dinner Course",
+                150000L,
+                CourseSessionType.DINNER,
+                CourseStatus.AVAILABLE,
+                List.of(
+                        new CreateCourseMenuCommand(
+                                CoursePart.APPETIZER,
+                                "제철 샐러드",
+                                1
+                        ),
+                        new CreateCourseMenuCommand(
+                                CoursePart.MAIN,
+                                "양갈비",
+                                1
+                        )
+                )
+        );
+
+        given(restaurantRepository.findById(restaurantId))
+                .willReturn(Optional.of(restaurant));
+
+        CourseException exception = assertThrows(
+                CourseException.class,
+                () -> restaurantCourseCommandService.createCourse(command)
+        );
+
+        assertThat(exception.getErrorCode())
+                .isEqualTo(CourseErrorCode.COURSE_400_INVALID_REQUEST.getCode());
+
+        then(restaurantCourseRepository).should(never()).save(any(RestaurantCourse.class));
+        then(restaurantCourseMenuRepository).should(never()).saveAll(anyList());
+    }
+
+    private Restaurant createRestaurant() {
+        return Restaurant.create(
+                UUID.randomUUID(),
+                "MicheLet Dining",
+                "서울특별시 강남구 테헤란로 123",
+                "02-1234-5678",
+                "파인다이닝 레스토랑",
+                LocalTime.of(10, 0),
+                90,
+                RestaurantStatus.OPEN,
+                "MON-FRI 11:00-20:00 / SAT,SUN CLOSED"
+        );
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.

- 식당 하위 코스 등록 API를 구현
- 코스 등록 요청 시 `menus[]`를 기반으로 서버에서 `menuComposition`을 생성하도록 구현
- 코스 기본 정보는 `p_restaurant_course`, 코스 메뉴 목록은 `p_restaurant_course_menu`에 저장되도록 처리
- 코스 등록 시 식당 존재 여부, 메뉴 목록 유효성, `sortOrder` 중복 여부를 검증하도록 구현
- 코스 등록 CommandService 테스트를 추가


## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #11 
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to # 

## ✅ 자체 체크리스트 (필수)
- [x] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [x] Postman 테스트 완료 (인증샷 첨부)
- [x] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [x] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 Postman 실행 화면을 여기에 첨부해 주세요.

<img width="1284" height="227" alt="스크린샷 2026-04-29 222936" src="https://github.com/user-attachments/assets/d703e80e-5e7d-4c31-be8a-545e59b23a9f" />
<img width="851" height="684" alt="스크린샷 2026-04-29 221339" src="https://github.com/user-attachments/assets/1442c56f-84bc-475d-ad3c-e9a8a1e48b86" />
<img width="849" height="683" alt="스크린샷 2026-04-29 221804" src="https://github.com/user-attachments/assets/938442ee-aee5-4dde-a574-0a8460be694b" />
<img width="840" height="674" alt="스크린샷 2026-04-29 221553" src="https://github.com/user-attachments/assets/a9d7ff2a-9ecb-4210-a807-820811fa7abf" />
<img width="846" height="680" alt="스크린샷 2026-04-29 221525" src="https://github.com/user-attachments/assets/42e7206a-bc75-492b-8b40-0f4ece94929c" />


## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.
> - [ ] 논의점

- 이번 PR은 Issue #11 범위에 맞춰 코스 등록 API까지만 구현
- 코스 조회, 코스 메뉴 조회 조립, 수정/삭제 API는 후속 이슈에서 진행할 예정
- `menuComposition`은 클라이언트 입력값을 받지 않고, 서버에서 `menus[]`의 `sortOrder` 기준으로 생성
- `RestaurantCourseMenu`는 현재 이슈 범위에서는 `courseId` UUID 기반으로 유지했습니다. JPA 연관관계 전환은 레스토랑/코스 리팩터링 이슈에서 별도 검토
<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신기능**
  * 코스 등록 기능 추가: 코스명, 가격, 세션(점심/저녁), 상태(사용 가능/미사용)와 순서가 지정된 다수의 메뉴 항목을 등록할 수 있습니다.
  * 서버에서 메뉴 조합 문자열을 생성하여 코스에 저장하고, 등록 결과로 코스 ID를 반환합니다.
* **테스트**
  * 코스 등록 정상 흐름 및 입력 유효성(중복 순서, 널 값, 미존재 레스토랑) 검증 테스트 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->