### PR TITLE
[FEAT] restaurant-service 도커 실행 환경 설정 추가

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,6 @@ out
 *.iml
 *.log
 src/docs
+.env
+.env.local
+.env.*.local

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+SPRING_PROFILES_ACTIVE=local
+DB_URL=jdbc:postgresql://localhost:5432/michelet_db
+DB_USERNAME=admin
+DB_PASSWORD=admin
+EUREKA_DEFAULT_ZONE=http://localhost:8761/eureka/

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 SPRING_PROFILES_ACTIVE=local
 DB_URL=jdbc:postgresql://localhost:5432/michelet_db
-DB_USERNAME=admin
-DB_PASSWORD=admin
+DB_USERNAME=your_db_username
+DB_PASSWORD=your_db_password
 EUREKA_DEFAULT_ZONE=http://localhost:8761/eureka/

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ out/
 .vscode/
 
 .env
+.env.local
+.env.*.local

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,24 @@
-# build stage
 FROM gradle:8.14.3-jdk17 AS builder
 WORKDIR /app
 
-COPY . .
+COPY build.gradle settings.gradle ./
 
-RUN gradle clean bootJar --no-daemon
+COPY gradlew ./
+COPY gradle ./gradle
 
-# runtime stage
+COPY src ./src
+
+RUN chmod +x ./gradlew
+RUN ./gradlew clean bootJar --no-daemon
+
+
 FROM eclipse-temurin:17-jre
 WORKDIR /app
+
+ENV SPRING_PROFILES_ACTIVE=docker
 
 COPY --from=builder /app/build/libs/*.jar app.jar
 
 EXPOSE 19300
 
-ENTRYPOINT ["java", "-jar", "app.jar"]
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/src/main/resources/application-docker.yml
+++ b/src/main/resources/application-docker.yml
@@ -17,7 +17,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
     properties:
       hibernate:
         default_schema: restaurant_service

--- a/src/main/resources/application-docker.yml
+++ b/src/main/resources/application-docker.yml
@@ -1,0 +1,27 @@
+server:
+  port: 19300
+
+spring:
+  application:
+    name: restaurant-service
+
+  datasource:
+    url: ${DB_URL:jdbc:postgresql://db:5432/michelet_db}
+    username: ${DB_USERNAME:admin}
+    password: ${DB_PASSWORD:admin}
+    driver-class-name: org.postgresql.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        # restaurant-service 전용 schema를 사용
+        default_schema: restaurant_service
+        format_sql: true
+    show-sql: true
+
+eureka:
+  client:
+    service-url:
+      defaultZone: ${EUREKA_DEFAULT_ZONE:http://eureka-server:8761/eureka/}

--- a/src/main/resources/application-docker.yml
+++ b/src/main/resources/application-docker.yml
@@ -2,13 +2,17 @@ server:
   port: 19300
 
 spring:
+  config:
+    activate:
+      on-profile: docker
+
   application:
     name: restaurant-service
 
   datasource:
     url: ${DB_URL:jdbc:postgresql://db:5432/michelet_db}
-    username: ${DB_USERNAME:admin}
-    password: ${DB_PASSWORD:admin}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
     driver-class-name: org.postgresql.Driver
 
   jpa:
@@ -16,9 +20,9 @@ spring:
       ddl-auto: update
     properties:
       hibernate:
-        # restaurant-service 전용 schema를 사용
         default_schema: restaurant_service
         format_sql: true
+    open-in-view: false
     show-sql: true
 
 eureka:

--- a/src/main/resources/application-docker.yml
+++ b/src/main/resources/application-docker.yml
@@ -27,5 +27,6 @@ spring:
 
 eureka:
   client:
+    enabled: ${EUREKA_CLIENT_ENABLED:true}
     service-url:
       defaultZone: ${EUREKA_DEFAULT_ZONE:http://eureka-server:8761/eureka/}

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -21,5 +21,6 @@ spring:
 
 eureka:
   client:
+    enabled: ${EUREKA_CLIENT_ENABLED:false}
     service-url:
       defaultZone: ${EUREKA_DEFAULT_ZONE:http://localhost:8761/eureka/}

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -7,20 +7,12 @@ spring:
     url: ${DB_URL:jdbc:postgresql://localhost:5432/michelet_db}
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
-    driver-class-name: org.postgresql.Driver
 
   jpa:
-    hibernate:
-      ddl-auto: update
     properties:
       hibernate:
         default_schema: restaurant_service
-        format_sql: true
-    open-in-view: false
-    show-sql: true
 
-eureka:
-  client:
-    enabled: ${EUREKA_CLIENT_ENABLED:false}
-    service-url:
-      defaultZone: ${EUREKA_DEFAULT_ZONE:http://localhost:8761/eureka/}
+  eureka:
+    client:
+      enabled: ${EUREKA_CLIENT_ENABLED:false}

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -1,18 +1,33 @@
+server:
+  port: 19300
+
 spring:
   config:
     activate:
       on-profile: local
 
+  application:
+    name: restaurant-service
+
   datasource:
     url: ${DB_URL:jdbc:postgresql://localhost:5432/michelet_db}
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
+    driver-class-name: org.postgresql.Driver
 
   jpa:
+    hibernate:
+      ddl-auto: update
     properties:
       hibernate:
         default_schema: restaurant_service
+        format_sql: true
+    open-in-view: false
+    show-sql: true
 
-  eureka:
-    client:
-      enabled: ${EUREKA_CLIENT_ENABLED:false}
+eureka:
+  client:
+    # local에서는 DB/API 테스트만 할 수 있도록 Eureka client를 기본 비활성화
+    enabled: ${EUREKA_CLIENT_ENABLED:false}
+    service-url:
+      defaultZone: ${EUREKA_DEFAULT_ZONE:http://localhost:8761/eureka/}

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -4,7 +4,7 @@ spring:
       on-profile: local
 
   datasource:
-    url: ${DB_URL}
+    url: ${DB_URL:jdbc:postgresql://localhost:5432/michelet_db}
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     driver-class-name: org.postgresql.Driver
@@ -14,5 +14,12 @@ spring:
       ddl-auto: update
     properties:
       hibernate:
+        default_schema: restaurant_service
         format_sql: true
     open-in-view: false
+    show-sql: true
+
+eureka:
+  client:
+    service-url:
+      defaultZone: ${EUREKA_DEFAULT_ZONE:http://localhost:8761/eureka/}


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.

- restaurant-service의 local/docker profile 설정을 분리
- local profile에서는 로컬에서 실행되는 애플리케이션이 infra PostgreSQL 컨테이너에 접근할 수 있도록 `localhost:5432` 기준 DB 연결을 설정
- docker profile에서는 컨테이너 내부 실행 환경에 맞춰 Docker Compose 서비스명 기준으로 DB/Eureka 연결을 설정
- DB username/password는 설정 파일에 직접 노출하지 않고 환경 변수로 주입되도록 변경
- `.env.example`을 정리하고, 실제 `.env` 파일은 Git/Docker build context에 포함되지 않도록 설정
- Dockerfile을 정리하여 docker profile 기반 실행이 가능하도록 구성

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #12 
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to # 

## ✅ 자체 체크리스트 (필수)
- [ ] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [ ] Postman 테스트 완료 (인증샷 첨부)
- [ ] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [ ] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 Postman 실행 화면을 여기에 첨부해 주세요.

<img width="324" height="528" alt="스크린샷 2026-04-30 000138" src="https://github.com/user-attachments/assets/4fa26d5f-44b6-41a2-b0ce-053d10f3ed48" />
<img width="1834" height="259" alt="스크린샷 2026-04-30 000156" src="https://github.com/user-attachments/assets/9400a3de-79bd-4483-a25b-0e42aeb13808" />




## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.
> - [ ] 논의점

- 이번 PR은 restaurant-service의 도커/로컬 실행 환경 설정 분리를 위한 작업
- 실제 DB 접속 정보는 `.env` 또는 Docker Compose 환경 변수로 주입하도록 구성
<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * Docker 컨테이너 배포를 위한 환경 설정 및 구성 파일 추가 (.env.example, Docker 전용 프로파일)
  * 로컬 개발과 Docker 환경의 독립적 설정 관리 구성 (application-local.yaml 업데이트, application-docker.yml 추가)
  * 환경 변수 파일 관리 정책 개선 (.gitignore, .dockerignore에 로컬 env 패턴 추가)
  * Docker 빌드/런타임 프로세스 및 ENTRYPOINT 최적화 (gradle wrapper 사용, 실행 환경 프로파일 설정)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->