### PR TITLE
[REFACTOR] 식당 목록 검색 및 상세 조회 응답 구조 정리

### DIFF
--- a/src/main/java/com/michelet/restaurant/application/query/RestaurantSearchCondition.java
+++ b/src/main/java/com/michelet/restaurant/application/query/RestaurantSearchCondition.java
@@ -9,17 +9,54 @@ import com.michelet.restaurant.domain.model.RestaurantStatus;
  * 페이징 정보는 Pageable로 별도 전달하므로 이 객체에는 검색 조건만 포함
  */
 public record RestaurantSearchCondition(
-        String name,
+        String keyword,
+        String region,
         RestaurantStatus status
 ) {
 
-    // 식당 이름 검색어가 존재하는지 여부를 반환
-    public boolean hasName() {
-        return name != null && !name.isBlank();
+    /**
+     * 기존 Controller/QueryDSL 코드와의 점진적 리팩터링을 위한 임시 생성자
+     *
+     * 다음 단계에서 Controller가 keyword, region, status를 모두 넘기도록 수정하면
+     * 이 생성자는 제거
+     */
+    public RestaurantSearchCondition(String keyword, RestaurantStatus status) {
+        this(keyword, null, status);
     }
 
-    // 식당 상태 조건이 존재하는지 여부를 반환
+    // 식당명 검색어가 존재하는지 확인
+    public boolean hasKeyword() {
+        return keyword != null && !keyword.isBlank();
+    }
+
+    // 지역 검색어가 존재하는지 확인
+    // MVP에서는 별도 region 컬럼이 없으므로 address 검색 조건으로 사용
+    public boolean hasRegion() {
+        return region != null && !region.isBlank();
+    }
+
+    // 식당 상태 조건이 존재하는지 확인
     public boolean hasStatus() {
         return status != null;
+    }
+
+    /**
+     * 기존 QueryDSL 코드와의 점진적 리팩터링을 위한 임시 메서드
+     *
+     * RestaurantQueryRepositoryImpl에서 hasKeyword(), keyword()를 사용하도록 수정한 뒤 제거
+     */
+    @Deprecated(forRemoval = true)
+    public boolean hasName() {
+        return hasKeyword();
+    }
+
+    /**
+     * 기존 QueryDSL 코드와의 점진적 리팩터링을 위한 임시 메서드
+     *
+     * RestaurantQueryRepositoryImpl에서 keyword()를 사용하도록 수정한 뒤 제거
+     */
+    @Deprecated(forRemoval = true)
+    public String name() {
+        return keyword;
     }
 }

--- a/src/main/java/com/michelet/restaurant/application/query/RestaurantSearchCondition.java
+++ b/src/main/java/com/michelet/restaurant/application/query/RestaurantSearchCondition.java
@@ -10,7 +10,7 @@ import com.michelet.restaurant.domain.model.RestaurantStatus;
  */
 public record RestaurantSearchCondition(
         String keyword,
-        String address,
+        String region,
         RestaurantStatus status
 ) {
 
@@ -19,8 +19,10 @@ public record RestaurantSearchCondition(
         return keyword != null && !keyword.isBlank();
     }
 
-    public boolean hasAddress() {
-        return address != null && !address.isBlank();
+    // 지역 검색어가 존재하는지 확인
+    // MVP에서는 별도 region 컬럼이 없으므로 address 검색 조건으로 사용
+    public boolean hasRegion() {
+        return region != null && !region.isBlank();
     }
 
     // 식당 상태 조건이 존재하는지 확인

--- a/src/main/java/com/michelet/restaurant/application/query/RestaurantSearchCondition.java
+++ b/src/main/java/com/michelet/restaurant/application/query/RestaurantSearchCondition.java
@@ -10,53 +10,21 @@ import com.michelet.restaurant.domain.model.RestaurantStatus;
  */
 public record RestaurantSearchCondition(
         String keyword,
-        String region,
+        String address,
         RestaurantStatus status
 ) {
-
-    /**
-     * 기존 Controller/QueryDSL 코드와의 점진적 리팩터링을 위한 임시 생성자
-     *
-     * 다음 단계에서 Controller가 keyword, region, status를 모두 넘기도록 수정하면
-     * 이 생성자는 제거
-     */
-    public RestaurantSearchCondition(String keyword, RestaurantStatus status) {
-        this(keyword, null, status);
-    }
 
     // 식당명 검색어가 존재하는지 확인
     public boolean hasKeyword() {
         return keyword != null && !keyword.isBlank();
     }
 
-    // 지역 검색어가 존재하는지 확인
-    // MVP에서는 별도 region 컬럼이 없으므로 address 검색 조건으로 사용
-    public boolean hasRegion() {
-        return region != null && !region.isBlank();
+    public boolean hasAddress() {
+        return address != null && !address.isBlank();
     }
 
     // 식당 상태 조건이 존재하는지 확인
     public boolean hasStatus() {
         return status != null;
-    }
-
-    /**
-     * 기존 QueryDSL 코드와의 점진적 리팩터링을 위한 임시 메서드
-     *
-     * RestaurantQueryRepositoryImpl에서 hasKeyword(), keyword()를 사용하도록 수정한 뒤 제거
-     */
-    @Deprecated(forRemoval = true)
-    public boolean hasName() {
-        return hasKeyword();
-    }
-
-    /**
-     * 기존 QueryDSL 코드와의 점진적 리팩터링을 위한 임시 메서드
-     *
-     * RestaurantQueryRepositoryImpl에서 keyword()를 사용하도록 수정한 뒤 제거
-     */
-    @Deprecated(forRemoval = true)
-    public String name() {
-        return keyword;
     }
 }

--- a/src/main/java/com/michelet/restaurant/application/result/CourseSummaryResult.java
+++ b/src/main/java/com/michelet/restaurant/application/result/CourseSummaryResult.java
@@ -1,0 +1,36 @@
+package com.michelet.restaurant.application.result;
+
+import com.michelet.restaurant.domain.model.CourseSessionType;
+import com.michelet.restaurant.domain.model.CourseStatus;
+import com.michelet.restaurant.domain.model.RestaurantCourse;
+
+import java.util.UUID;
+
+public record CourseSummaryResult(
+
+        UUID courseId,
+        String name,
+        Long price,
+
+        // 사용자에게 노출할 코스 메뉴 요약 문자열
+        // menus[]를 기반으로 서버에서 생성해 저장한 값
+        String menuComposition,
+
+        // 런치/디너 등 코스 제공 세션 타입
+        CourseSessionType sessionType,
+
+        // 코스 판매 가능 상태
+        CourseStatus status
+) {
+
+    public static CourseSummaryResult from(RestaurantCourse course) {
+        return new CourseSummaryResult(
+                course.getCourseId(),
+                course.getName(),
+                course.getPrice(),
+                course.getMenuComposition(),
+                course.getSessionType(),
+                course.getStatus()
+        );
+    }
+}

--- a/src/main/java/com/michelet/restaurant/application/result/GetRestaurantResult.java
+++ b/src/main/java/com/michelet/restaurant/application/result/GetRestaurantResult.java
@@ -4,6 +4,7 @@ import com.michelet.restaurant.domain.model.Restaurant;
 import com.michelet.restaurant.domain.model.RestaurantStatus;
 
 import java.time.LocalTime;
+import java.util.List;
 import java.util.UUID;
 
 /**
@@ -19,14 +20,22 @@ public record GetRestaurantResult(
         String address,
         String phone,
         String description,
+
+        // 매일 반복되는 예약 오픈 시각
         LocalTime reservationOpenAt,
         Integer avgMealDurationMin,
         RestaurantStatus status,
-        String businessHours
+        String businessHours,
+
+        /**
+         *  식당 상세 조회에서 함께 내려줄 코스 요약 목록
+         *  개별 코스 메뉴 menus[] 전체가 아니라 menuComposition 중심의 요약 정보만 포함
+         */
+        List<CourseSummaryResult> courses
 ) {
 
     // Restaurant 엔티티를 단건 조회 결과 DTO로 변환
-    public static GetRestaurantResult from(Restaurant restaurant) {
+    public static GetRestaurantResult of(Restaurant restaurant, List<CourseSummaryResult> courses) {
         return new GetRestaurantResult(
                 restaurant.getRestaurantId(),
                 restaurant.getOwnerId(),
@@ -37,7 +46,8 @@ public record GetRestaurantResult(
                 restaurant.getReservationOpenAt(),
                 restaurant.getAvgMealDurationMin(),
                 restaurant.getStatus(),
-                restaurant.getBusinessHours()
+                restaurant.getBusinessHours(),
+                courses
         );
     }
 

--- a/src/main/java/com/michelet/restaurant/application/service/query/RestaurantQueryService.java
+++ b/src/main/java/com/michelet/restaurant/application/service/query/RestaurantQueryService.java
@@ -2,17 +2,20 @@ package com.michelet.restaurant.application.service.query;
 
 import com.michelet.restaurant.application.query.RestaurantSearchCondition;
 import com.michelet.restaurant.application.query.repository.RestaurantQueryRepository;
+import com.michelet.restaurant.application.result.CourseSummaryResult;
 import com.michelet.restaurant.application.result.GetRestaurantResult;
 import com.michelet.restaurant.application.result.RestaurantSummaryResult;
 import com.michelet.restaurant.domain.exception.RestaurantErrorCode;
 import com.michelet.restaurant.domain.exception.RestaurantException;
 import com.michelet.restaurant.domain.model.Restaurant;
+import com.michelet.restaurant.domain.repository.RestaurantCourseRepository;
 import com.michelet.restaurant.domain.repository.RestaurantRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -21,10 +24,12 @@ public class RestaurantQueryService {
 
     private final RestaurantRepository restaurantRepository;
     private final RestaurantQueryRepository restaurantQueryRepository;
+    private final RestaurantCourseRepository restaurantCourseRepository;
 
-    public RestaurantQueryService(RestaurantRepository restaurantRepository, RestaurantQueryRepository restaurantQueryRepository) {
+    public RestaurantQueryService(RestaurantRepository restaurantRepository, RestaurantQueryRepository restaurantQueryRepository, RestaurantCourseRepository restaurantCourseRepository) {
         this.restaurantRepository = restaurantRepository;
         this.restaurantQueryRepository = restaurantQueryRepository;
+        this.restaurantCourseRepository = restaurantCourseRepository;
     }
 
     /**
@@ -33,11 +38,18 @@ public class RestaurantQueryService {
      * 외부 상세 조회 API / 내부 조회 API에서 공통으로 사용하는 조회 메서드
      * 식당이 존재하지 않으면 RESTAURANT_404_NOT_FOUND 예외던짐
      */
+    @Transactional(readOnly = true)
     public GetRestaurantResult getRestaurant(UUID restaurantId) {
         Restaurant restaurant = restaurantRepository.findById(restaurantId)
                 .orElseThrow(() -> new RestaurantException(RestaurantErrorCode.RESTAURANT_404_NOT_FOUND));
 
-        return GetRestaurantResult.from(restaurant);
+        List<CourseSummaryResult> courses = restaurantCourseRepository
+                .findAllByRestaurantIdOrderByCreatedAtAsc(restaurantId)
+                .stream()
+                .map(course -> CourseSummaryResult.from(course))
+                .toList();
+
+        return GetRestaurantResult.of(restaurant, courses);
     }
 
     /**
@@ -46,6 +58,7 @@ public class RestaurantQueryService {
      * QueryDSL 기반 Query Repository에 검색 조건과 Pageable을 전달해
      * 목록 조회 및 검색 조회를 공통 처리
      */
+    @Transactional(readOnly = true)
     public Page<RestaurantSummaryResult> getRestaurants(RestaurantSearchCondition condition, Pageable pageable) {
 
         return restaurantQueryRepository.search(condition, pageable);

--- a/src/main/java/com/michelet/restaurant/domain/repository/RestaurantCourseRepository.java
+++ b/src/main/java/com/michelet/restaurant/domain/repository/RestaurantCourseRepository.java
@@ -2,9 +2,15 @@ package com.michelet.restaurant.domain.repository;
 
 import com.michelet.restaurant.domain.model.RestaurantCourse;
 
+import java.util.List;
+import java.util.UUID;
+
 public interface RestaurantCourseRepository {
 
     // 코스 엔티티를 저장
     // 실제 저장 방식은 infrastructure 계층의 JpaRepository 구현체에 위임
     RestaurantCourse save(RestaurantCourse restaurantCourse);
+
+    // 식당 상세 조회에서 해당 식당의 코스 요약 목록 조회
+    List<RestaurantCourse> findAllByRestaurantIdOrderByCreatedAtAsc(UUID restaurantId);
 }

--- a/src/main/java/com/michelet/restaurant/infrastructure/persistence/RestaurantCourseJpaRepository.java
+++ b/src/main/java/com/michelet/restaurant/infrastructure/persistence/RestaurantCourseJpaRepository.java
@@ -3,11 +3,14 @@ package com.michelet.restaurant.infrastructure.persistence;
 import com.michelet.restaurant.domain.model.RestaurantCourse;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface RestaurantCourseJpaRepository extends JpaRepository<RestaurantCourse, UUID> {
 
-    // 현재 Issue #11 범위는 코스 등록
-    // 등록에는 JpaRepository 기본 save 메서드만 필요하므로 별도 조회 메서드는 추가x
-
+    /**
+     * 식당 상세 조회에서 해당 식당의 코스 요약 목록 조회
+     * MVP에서 코스 메뉴 상세목록 까지 조회 하지 않음
+     */
+    List<RestaurantCourse> findAllByRestaurantIdOrderByCreatedAtAsc(UUID restaurantId);
 }

--- a/src/main/java/com/michelet/restaurant/infrastructure/persistence/RestaurantCourseRepositoryImpl.java
+++ b/src/main/java/com/michelet/restaurant/infrastructure/persistence/RestaurantCourseRepositoryImpl.java
@@ -4,6 +4,9 @@ import com.michelet.restaurant.domain.model.RestaurantCourse;
 import com.michelet.restaurant.domain.repository.RestaurantCourseRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+import java.util.UUID;
+
 @Repository
 public class RestaurantCourseRepositoryImpl implements RestaurantCourseRepository {
 
@@ -16,5 +19,10 @@ public class RestaurantCourseRepositoryImpl implements RestaurantCourseRepositor
     @Override
     public RestaurantCourse save(RestaurantCourse restaurantCourse) {
         return restaurantCourseJpaRepository.save(restaurantCourse);
+    }
+
+    @Override
+    public List<RestaurantCourse> findAllByRestaurantIdOrderByCreatedAtAsc(UUID restaurantId) {
+        return restaurantCourseJpaRepository.findAllByRestaurantIdOrderByCreatedAtAsc(restaurantId);
     }
 }

--- a/src/main/java/com/michelet/restaurant/infrastructure/persistence/query/RestaurantQueryRepositoryImpl.java
+++ b/src/main/java/com/michelet/restaurant/infrastructure/persistence/query/RestaurantQueryRepositoryImpl.java
@@ -22,7 +22,7 @@ import static com.michelet.restaurant.domain.model.QRestaurant.restaurant;
  * 식당 목록/검색 조회용 QueryDSL 구현체
  *
  * application 계층의 RestaurantQueryRepository를 QueryDSL 기반으로 구현
- * MVP 단계에서는 이름(name), 상태(status) 조건만 지원
+ * 검색 조건은 keyword, region, status
  */
 @Repository
 public class RestaurantQueryRepositoryImpl implements RestaurantQueryRepository {
@@ -33,15 +33,7 @@ public class RestaurantQueryRepositoryImpl implements RestaurantQueryRepository 
         this.jpaQueryFactory = jpaQueryFactory;
     }
 
-    /**
-     * 식당 목록/검색 결과를 페이지 단위로 조회
-     *
-     * 지원 조건
-     * - name: 식당 이름 포함 검색
-     * - status: 식당 상태 일치 검색
-     *
-     * 페이징은 Pageable의 offset, pageSize를 사용
-     */
+    // 식당 목록/검색 결과를 페이지 단위로 조회
     @Override
     public Page<RestaurantSummaryResult> search(RestaurantSearchCondition condition, Pageable pageable) {
         BooleanBuilder predicate = buildPredicate(condition);
@@ -54,7 +46,7 @@ public class RestaurantQueryRepositoryImpl implements RestaurantQueryRepository 
                 .orderBy(getOrderSpecifiers(pageable))
                 .fetch()
                 .stream()
-                .map(RestaurantSummaryResult::from)
+                .map(entity -> RestaurantSummaryResult.from(entity))
                 .toList();
 
         Long total = jpaQueryFactory
@@ -66,17 +58,22 @@ public class RestaurantQueryRepositoryImpl implements RestaurantQueryRepository 
         return new PageImpl<>(content, pageable, total != null ? total : 0L);
     }
 
-    // 검색 조건을 QueryDSL predicate로 조합
-
     private BooleanBuilder buildPredicate(RestaurantSearchCondition condition) {
         BooleanBuilder builder = new BooleanBuilder();
+
+        // soft delete 된 식당은 목록/검색 조회에서 제외한다.
+        builder.and(restaurant.deletedAt.isNull());
 
         if (condition == null) {
             return builder;
         }
 
-        if (condition.hasName()) {
-            builder.and(restaurant.name.containsIgnoreCase(condition.name().trim()));
+        if (condition.hasKeyword()) {
+            builder.and(restaurant.name.containsIgnoreCase(condition.keyword().trim()));
+        }
+
+        if (condition.hasRegion()) {
+            builder.and(restaurant.address.containsIgnoreCase(condition.region().trim()));
         }
 
         if (condition.hasStatus()) {
@@ -86,12 +83,7 @@ public class RestaurantQueryRepositoryImpl implements RestaurantQueryRepository 
         return builder;
     }
 
-    /**
-     * Pageable의 Sort 정보를 QueryDSL OrderSpecifier로 변환
-     *
-     * 허용하지 않은 정렬 필드는 무시
-     * 최종적으로 유효한 정렬 조건이 하나도 없으면 createdAt desc를 기본 정렬로 사용
-     */
+    // Pageable의 Sort 정보를 QueryDSL OrderSpecifier로 변환
     private OrderSpecifier<?>[] getOrderSpecifiers(Pageable pageable) {
         List<OrderSpecifier<?>> orderSpecifiers = new ArrayList<>();
 
@@ -103,7 +95,7 @@ public class RestaurantQueryRepositoryImpl implements RestaurantQueryRepository 
                 case "name" -> orderSpecifiers.add(new OrderSpecifier<>(direction, restaurant.name));
                 case "status" -> orderSpecifiers.add(new OrderSpecifier<>(direction, restaurant.status));
                 default -> {
-                    // 허용하지 않은 정렬 필드는 아무 작업도 하지 않음
+                    // 허용하지 않은 정렬 필드는 무시
                 }
             }
         }
@@ -114,5 +106,4 @@ public class RestaurantQueryRepositoryImpl implements RestaurantQueryRepository 
 
         return orderSpecifiers.toArray(new OrderSpecifier[0]);
     }
-
 }

--- a/src/main/java/com/michelet/restaurant/infrastructure/persistence/query/RestaurantQueryRepositoryImpl.java
+++ b/src/main/java/com/michelet/restaurant/infrastructure/persistence/query/RestaurantQueryRepositoryImpl.java
@@ -61,7 +61,7 @@ public class RestaurantQueryRepositoryImpl implements RestaurantQueryRepository 
     private BooleanBuilder buildPredicate(RestaurantSearchCondition condition) {
         BooleanBuilder builder = new BooleanBuilder();
 
-        // soft delete 된 식당은 목록/검색 조회에서 제외
+        // soft delete 된 식당은 목록/검색 조회에서 제외한다.
         builder.and(restaurant.deletedAt.isNull());
 
         if (condition == null) {
@@ -72,8 +72,10 @@ public class RestaurantQueryRepositoryImpl implements RestaurantQueryRepository 
             builder.and(restaurant.name.containsIgnoreCase(condition.keyword().trim()));
         }
 
-        if (condition.hasAddress()) {
-            builder.and(restaurant.address.containsIgnoreCase(condition.address().trim()));
+        // region은 API 검색 조건
+        // MVP에는 별도 region 컬럼이 없으므로 address 컬럼에 대한 포함 검색으로 처리
+        if (condition.hasRegion()) {
+            builder.and(restaurant.address.containsIgnoreCase(condition.region().trim()));
         }
 
         if (condition.hasStatus()) {

--- a/src/main/java/com/michelet/restaurant/infrastructure/persistence/query/RestaurantQueryRepositoryImpl.java
+++ b/src/main/java/com/michelet/restaurant/infrastructure/persistence/query/RestaurantQueryRepositoryImpl.java
@@ -61,7 +61,7 @@ public class RestaurantQueryRepositoryImpl implements RestaurantQueryRepository 
     private BooleanBuilder buildPredicate(RestaurantSearchCondition condition) {
         BooleanBuilder builder = new BooleanBuilder();
 
-        // soft delete 된 식당은 목록/검색 조회에서 제외한다.
+        // soft delete 된 식당은 목록/검색 조회에서 제외
         builder.and(restaurant.deletedAt.isNull());
 
         if (condition == null) {

--- a/src/main/java/com/michelet/restaurant/infrastructure/persistence/query/RestaurantQueryRepositoryImpl.java
+++ b/src/main/java/com/michelet/restaurant/infrastructure/persistence/query/RestaurantQueryRepositoryImpl.java
@@ -72,8 +72,8 @@ public class RestaurantQueryRepositoryImpl implements RestaurantQueryRepository 
             builder.and(restaurant.name.containsIgnoreCase(condition.keyword().trim()));
         }
 
-        if (condition.hasRegion()) {
-            builder.and(restaurant.address.containsIgnoreCase(condition.region().trim()));
+        if (condition.hasAddress()) {
+            builder.and(restaurant.address.containsIgnoreCase(condition.address().trim()));
         }
 
         if (condition.hasStatus()) {

--- a/src/main/java/com/michelet/restaurant/presentation/controller/external/RestaurantController.java
+++ b/src/main/java/com/michelet/restaurant/presentation/controller/external/RestaurantController.java
@@ -72,18 +72,24 @@ public class RestaurantController {
 
     /**
      * 식당 목록/검색 조회 API
-     * <p>
-     * name, status 조건으로 식당 목록을 검색
      * Pageable 기본값은 createdAt desc, size 10으로 설정
      */
     @GetMapping
-    public ApiResponse<Page<RestaurantSummaryResponse>> getRestaurants(@RequestParam(required = false) String name,
+    public ApiResponse<Page<RestaurantSummaryResponse>> getRestaurants(@RequestParam(required = false) String keyword,
+                                                                       @RequestParam(required = false) String region,
                                                                        @RequestParam(required = false) RestaurantStatus status,
                                                                        @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        // region은 별도 컬럼이 없으므로 QueryDSL 단계에서 address 포함 검색으로 처리
+        RestaurantSearchCondition condition = new RestaurantSearchCondition(
+                keyword,
+                region,
+                status
+        );
 
-        RestaurantSearchCondition condition = new RestaurantSearchCondition(name, status);
-
-        Page<RestaurantSummaryResult> resultPage = restaurantQueryService.getRestaurants(condition, pageable);
+        Page<RestaurantSummaryResult> resultPage = restaurantQueryService.getRestaurants(
+                condition,
+                pageable
+        );
 
         Page<RestaurantSummaryResponse> responsePage =
                 resultPage.map(result -> RestaurantSummaryResponse.from(result));

--- a/src/main/java/com/michelet/restaurant/presentation/controller/external/RestaurantController.java
+++ b/src/main/java/com/michelet/restaurant/presentation/controller/external/RestaurantController.java
@@ -76,13 +76,12 @@ public class RestaurantController {
      */
     @GetMapping
     public ApiResponse<Page<RestaurantSummaryResponse>> getRestaurants(@RequestParam(required = false) String keyword,
-                                                                       @RequestParam(required = false) String region,
+                                                                       @RequestParam(required = false) String address,
                                                                        @RequestParam(required = false) RestaurantStatus status,
                                                                        @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
-        // region은 별도 컬럼이 없으므로 QueryDSL 단계에서 address 포함 검색으로 처리
         RestaurantSearchCondition condition = new RestaurantSearchCondition(
                 keyword,
-                region,
+                address,
                 status
         );
 

--- a/src/main/java/com/michelet/restaurant/presentation/controller/external/RestaurantController.java
+++ b/src/main/java/com/michelet/restaurant/presentation/controller/external/RestaurantController.java
@@ -9,10 +9,7 @@ import com.michelet.restaurant.application.result.RestaurantSummaryResult;
 import com.michelet.restaurant.application.service.command.RestaurantCommandService;
 import com.michelet.restaurant.application.service.query.RestaurantQueryService;
 import com.michelet.restaurant.domain.model.RestaurantStatus;
-import com.michelet.restaurant.presentation.dto.CreateRestaurantRequest;
-import com.michelet.restaurant.presentation.dto.CreateRestaurantResponse;
-import com.michelet.restaurant.presentation.dto.GetRestaurantResponse;
-import com.michelet.restaurant.presentation.dto.RestaurantSummaryResponse;
+import com.michelet.restaurant.presentation.dto.*;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -75,10 +72,11 @@ public class RestaurantController {
      * Pageable 기본값은 createdAt desc, size 10으로 설정
      */
     @GetMapping
-    public ApiResponse<Page<RestaurantSummaryResponse>> getRestaurants(@RequestParam(required = false) String keyword,
-                                                                       @RequestParam(required = false) String address,
-                                                                       @RequestParam(required = false) RestaurantStatus status,
-                                                                       @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+    public ApiResponse<PageResponse<RestaurantSummaryResponse>> getRestaurants(@RequestParam(required = false) String keyword,
+                                                                               @RequestParam(required = false) String address,
+                                                                               @RequestParam(required = false) RestaurantStatus status,
+                                                                               @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+
         RestaurantSearchCondition condition = new RestaurantSearchCondition(
                 keyword,
                 address,
@@ -93,6 +91,6 @@ public class RestaurantController {
         Page<RestaurantSummaryResponse> responsePage =
                 resultPage.map(result -> RestaurantSummaryResponse.from(result));
 
-        return ApiResponse.ok(responsePage);
+        return ApiResponse.ok(PageResponse.from(responsePage));
     }
 }

--- a/src/main/java/com/michelet/restaurant/presentation/controller/external/RestaurantController.java
+++ b/src/main/java/com/michelet/restaurant/presentation/controller/external/RestaurantController.java
@@ -73,13 +73,13 @@ public class RestaurantController {
      */
     @GetMapping
     public ApiResponse<PageResponse<RestaurantSummaryResponse>> getRestaurants(@RequestParam(required = false) String keyword,
-                                                                               @RequestParam(required = false) String address,
+                                                                               @RequestParam(required = false) String region,
                                                                                @RequestParam(required = false) RestaurantStatus status,
                                                                                @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
 
         RestaurantSearchCondition condition = new RestaurantSearchCondition(
                 keyword,
-                address,
+                region,
                 status
         );
 

--- a/src/main/java/com/michelet/restaurant/presentation/dto/CourseSummaryResponse.java
+++ b/src/main/java/com/michelet/restaurant/presentation/dto/CourseSummaryResponse.java
@@ -1,0 +1,34 @@
+package com.michelet.restaurant.presentation.dto;
+
+import com.michelet.restaurant.application.result.CourseSummaryResult;
+import com.michelet.restaurant.domain.model.CourseSessionType;
+import com.michelet.restaurant.domain.model.CourseStatus;
+
+import java.util.UUID;
+
+// 식당 상세 응답에 들어갈 코스 요약 Response DTO
+public record CourseSummaryResponse(
+        UUID courseId,
+        String name,
+        Long price,
+
+        // 사용자에게 노출할 코스 메뉴 요약 문자열
+        // 개별 menus[]가 아니라 서버가 생성한 요약값만 내림
+        String menuComposition,
+
+        // 런치/디너 등 코스 제공 세션 타입
+        CourseSessionType sessionType,
+        CourseStatus status
+) {
+
+    public static CourseSummaryResponse from(CourseSummaryResult result) {
+        return new CourseSummaryResponse(
+                result.courseId(),
+                result.name(),
+                result.price(),
+                result.menuComposition(),
+                result.sessionType(),
+                result.status()
+        );
+    }
+}

--- a/src/main/java/com/michelet/restaurant/presentation/dto/GetRestaurantResponse.java
+++ b/src/main/java/com/michelet/restaurant/presentation/dto/GetRestaurantResponse.java
@@ -4,6 +4,7 @@ import com.michelet.restaurant.application.result.GetRestaurantResult;
 import com.michelet.restaurant.domain.model.RestaurantStatus;
 
 import java.time.LocalTime;
+import java.util.List;
 import java.util.UUID;
 
 /**
@@ -21,7 +22,8 @@ public record GetRestaurantResponse(
         LocalTime reservationOpenAt,
         Integer avgMealDurationMin,
         RestaurantStatus status,
-        String businessHours
+        String businessHours,
+        List<CourseSummaryResponse> courses
 ) {
 
     /**
@@ -39,7 +41,10 @@ public record GetRestaurantResponse(
                 result.reservationOpenAt(),
                 result.avgMealDurationMin(),
                 result.status(),
-                result.businessHours()
+                result.businessHours(),
+                result.courses().stream()
+                        .map(course -> CourseSummaryResponse.from(course))
+                        .toList()
         );
     }
 }

--- a/src/main/java/com/michelet/restaurant/presentation/dto/PageResponse.java
+++ b/src/main/java/com/michelet/restaurant/presentation/dto/PageResponse.java
@@ -1,0 +1,31 @@
+package com.michelet.restaurant.presentation.dto;
+
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+public record PageResponse<T>(
+
+        // 현재 페이지에 포함된 실제 응답 목록
+        List<T> content,
+
+        // 현재 페이지 번호 Spring Pageable 기준으로 0부터 시작
+        int page,
+
+        // 한 페이지에 요청한 데이터 개수
+        int size,
+
+        // 검색 조건에 해당하는 전체 데이터 개수
+        long totalElements
+
+) {
+
+    public static <T> PageResponse<T> from(Page<T> page) {
+        return new PageResponse<>(
+                page.getContent(),
+                page.getNumber(),
+                page.getSize(),
+                page.getTotalElements()
+        );
+    }
+}

--- a/src/test/java/com/michelet/restaurant/application/service/query/RestaurantQueryServiceTest.java
+++ b/src/test/java/com/michelet/restaurant/application/service/query/RestaurantQueryServiceTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalTime;
 import java.util.List;
@@ -52,6 +53,8 @@ class RestaurantQueryServiceTest {
                 "MON-FRI 11:00-20:00 / SAT,SUN CLOSED"
         );
 
+        ReflectionTestUtils.setField(restaurant, "restaurantId", restaurantId);
+
         RestaurantCourse course = RestaurantCourse.create(
                 restaurantId,
                 "Dinner Course",
@@ -69,7 +72,7 @@ class RestaurantQueryServiceTest {
 
         GetRestaurantResult result = restaurantQueryService.getRestaurant(restaurantId);
 
-        assertThat(result.restaurantId()).isEqualTo(restaurant.getRestaurantId());
+        assertThat(result.restaurantId()).isEqualTo(restaurantId);
         assertThat(result.name()).isEqualTo("MicheLet Dining");
         assertThat(result.address()).isEqualTo("서울특별시 강남구 테헤란로 123");
 

--- a/src/test/java/com/michelet/restaurant/application/service/query/RestaurantQueryServiceTest.java
+++ b/src/test/java/com/michelet/restaurant/application/service/query/RestaurantQueryServiceTest.java
@@ -1,0 +1,85 @@
+package com.michelet.restaurant.application.service.query;
+
+import com.michelet.restaurant.application.query.repository.RestaurantQueryRepository;
+import com.michelet.restaurant.application.result.GetRestaurantResult;
+import com.michelet.restaurant.domain.model.*;
+import com.michelet.restaurant.domain.repository.RestaurantCourseRepository;
+import com.michelet.restaurant.domain.repository.RestaurantRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+
+@ExtendWith(MockitoExtension.class)
+class RestaurantQueryServiceTest {
+
+    @InjectMocks
+    private RestaurantQueryService restaurantQueryService;
+
+    @Mock
+    private RestaurantRepository restaurantRepository;
+
+    @Mock
+    private RestaurantCourseRepository restaurantCourseRepository;
+
+    @Mock
+    private RestaurantQueryRepository restaurantQueryRepository;
+
+    @Test
+    @DisplayName("식당 상세 조회")
+    void 식당상세조회() {
+        UUID restaurantId = UUID.randomUUID();
+        Restaurant restaurant = Restaurant.create(
+                UUID.randomUUID(),
+                "MicheLet Dining",
+                "서울특별시 강남구 테헤란로 123",
+                "02-1234-5678",
+                "파인다이닝 레스토랑",
+                LocalTime.of(10, 0),
+                90,
+                RestaurantStatus.OPEN,
+                "MON-FRI 11:00-20:00 / SAT,SUN CLOSED"
+        );
+
+        RestaurantCourse course = RestaurantCourse.create(
+                restaurantId,
+                "Dinner Course",
+                150000L,
+                "애피타이저: 제철 샐러드 / 메인: 양갈비 / 디저트: 바닐라 무스",
+                CourseSessionType.DINNER,
+                CourseStatus.AVAILABLE
+        );
+
+        given(restaurantRepository.findById(restaurantId))
+                .willReturn(Optional.of(restaurant));
+
+        given(restaurantCourseRepository.findAllByRestaurantIdOrderByCreatedAtAsc(restaurantId))
+                .willReturn(List.of(course));
+
+        GetRestaurantResult result = restaurantQueryService.getRestaurant(restaurantId);
+
+        assertThat(result.restaurantId()).isEqualTo(restaurant.getRestaurantId());
+        assertThat(result.name()).isEqualTo("MicheLet Dining");
+        assertThat(result.address()).isEqualTo("서울특별시 강남구 테헤란로 123");
+
+        assertThat(result.courses()).hasSize(1);
+        assertThat(result.courses().get(0).courseId()).isEqualTo(course.getCourseId());
+        assertThat(result.courses().get(0).name()).isEqualTo("Dinner Course");
+        assertThat(result.courses().get(0).price()).isEqualTo(150000L);
+        assertThat(result.courses().get(0).menuComposition()).isEqualTo("애피타이저: 제철 샐러드 / 메인: 양갈비 / 디저트: 바닐라 무스");
+        assertThat(result.courses().get(0).sessionType()).isEqualTo(CourseSessionType.DINNER);
+        assertThat(result.courses().get(0).status()).isEqualTo(CourseStatus.AVAILABLE);
+
+    }
+}

--- a/src/test/java/com/michelet/restaurant/infrastructure/persistence/query/RestaurantQueryRepositoryImplTest.java
+++ b/src/test/java/com/michelet/restaurant/infrastructure/persistence/query/RestaurantQueryRepositoryImplTest.java
@@ -48,7 +48,11 @@ class RestaurantQueryRepositoryImplTest {
                 생성("Another Restaurant", RestaurantStatus.OPEN)
         );
 
-        RestaurantSearchCondition condition = new RestaurantSearchCondition(null, null);
+        RestaurantSearchCondition condition = new RestaurantSearchCondition(
+                null,
+                null,
+                null
+        );
         PageRequest pageable = PageRequest.of(0, 10);
 
         Page<RestaurantSummaryResult> result =
@@ -77,7 +81,11 @@ class RestaurantQueryRepositoryImplTest {
         );
 
         RestaurantSearchCondition condition =
-                new RestaurantSearchCondition("MicheLet", RestaurantStatus.OPEN);
+                new RestaurantSearchCondition(
+                        "MicheLet",
+                        null,
+                        RestaurantStatus.OPEN
+                );
         PageRequest pageable = PageRequest.of(0, 1);
 
         Page<RestaurantSummaryResult> result =

--- a/src/test/java/com/michelet/restaurant/infrastructure/persistence/query/RestaurantQueryRepositoryImplTest.java
+++ b/src/test/java/com/michelet/restaurant/infrastructure/persistence/query/RestaurantQueryRepositoryImplTest.java
@@ -2,8 +2,8 @@ package com.michelet.restaurant.infrastructure.persistence.query;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.michelet.restaurant.application.query.repository.RestaurantQueryRepository;
 import com.michelet.restaurant.application.query.RestaurantSearchCondition;
+import com.michelet.restaurant.application.query.repository.RestaurantQueryRepository;
 import com.michelet.restaurant.application.result.RestaurantSummaryResult;
 import com.michelet.restaurant.domain.model.Restaurant;
 import com.michelet.restaurant.domain.model.RestaurantStatus;
@@ -43,9 +43,9 @@ class RestaurantQueryRepositoryImplTest {
     @DisplayName("식당 목록 조회")
     void 식당목록조회() {
         저장(
-                생성("MicheLet Dining", RestaurantStatus.OPEN),
-                생성("MicheLet Bistro", RestaurantStatus.CLOSED),
-                생성("Another Restaurant", RestaurantStatus.OPEN)
+                생성("MicheLet Dining", "서울특별시 강남구 테헤란로 123", RestaurantStatus.OPEN),
+                생성("MicheLet Bistro", "서울특별시 성동구 연무장길 10", RestaurantStatus.CLOSED),
+                생성("Another Restaurant", "서울특별시 마포구 양화로 20", RestaurantStatus.OPEN)
         );
 
         RestaurantSearchCondition condition = new RestaurantSearchCondition(
@@ -62,22 +62,22 @@ class RestaurantQueryRepositoryImplTest {
         assertThat(result.getTotalPages()).isEqualTo(1);
         assertThat(result.getContent()).hasSize(3);
         assertThat(result.getContent())
-                .extracting(RestaurantSummaryResult::name)
+                .extracting(resultItem -> resultItem.name())
                 .contains("MicheLet Dining", "MicheLet Bistro", "Another Restaurant");
     }
 
     /**
-     * 이름 + 상태 조건이 실제로 적용되고,
+     * 이름 + 지역 + 상태 조건이 실제로 적용되고
      * Pageable 기준으로 페이징이 동작하는지 확인
      */
     @Test
     @DisplayName("식당 검색 조회")
     void 식당검색조회() {
         저장(
-                생성("MicheLet Dining", RestaurantStatus.OPEN),
-                생성("MicheLet Closed", RestaurantStatus.CLOSED),
-                생성("Another Restaurant", RestaurantStatus.OPEN),
-                생성("MicheLet Bistro", RestaurantStatus.OPEN)
+                생성("MicheLet Dining", "서울특별시 강남구 테헤란로 123", RestaurantStatus.OPEN),
+                생성("MicheLet Closed", "서울특별시 강남구 테헤란로 456", RestaurantStatus.CLOSED),
+                생성("Another Restaurant", "서울특별시 강남구 테헤란로 789", RestaurantStatus.OPEN),
+                생성("MicheLet Bistro", "서울특별시 성동구 연무장길 10", RestaurantStatus.OPEN)
         );
 
         RestaurantSearchCondition condition = new RestaurantSearchCondition(
@@ -90,19 +90,26 @@ class RestaurantQueryRepositoryImplTest {
         Page<RestaurantSummaryResult> result =
                 restaurantQueryRepository.search(condition, pageable);
 
-        assertThat(result.getTotalElements()).isEqualTo(2);
-        assertThat(result.getTotalPages()).isEqualTo(2);
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getTotalPages()).isEqualTo(1);
         assertThat(result.getContent()).hasSize(1);
         assertThat(result.getContent().get(0).status()).isEqualTo(RestaurantStatus.OPEN);
-        assertThat(result.getContent().get(0).name()).contains("MicheLet");
+        assertThat(result.getContent().get(0).name()).isEqualTo("MicheLet Dining");
+        assertThat(result.getContent().get(0).address()).contains("강남구");
     }
 
     @Test
-    @DisplayName("지역으로 식당을 검색한다")
+    @DisplayName("지역으로 식당을 검색")
     void 지역으로식당검색() {
+        저장(
+                생성("MicheLet Gangnam", "서울특별시 강남구 테헤란로 123", RestaurantStatus.OPEN),
+                생성("MicheLet Seongsu", "서울특별시 성동구 연무장길 10", RestaurantStatus.OPEN),
+                생성("MicheLet Mapo", "서울특별시 마포구 양화로 20", RestaurantStatus.OPEN)
+        );
+
         RestaurantSearchCondition condition = new RestaurantSearchCondition(
                 null,
-                "강남구",
+                "강남",
                 null
         );
 
@@ -111,17 +118,18 @@ class RestaurantQueryRepositoryImplTest {
                 PageRequest.of(0, 10)
         );
 
-        assertThat(result.getContent())
-                .extracting(resultItem -> resultItem.address())
-                .allMatch(address -> address.contains("강남구"));
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).name()).isEqualTo("MicheLet Gangnam");
+        assertThat(result.getContent().get(0).address()).contains("강남구");
     }
 
     // 테스트용 식당 엔티티를 생성
-    private Restaurant 생성(String name, RestaurantStatus status) {
+    private Restaurant 생성(String name, String address, RestaurantStatus status) {
         return Restaurant.create(
                 UUID.randomUUID(),
                 name,
-                "서울특별시 강남구 테헤란로 123",
+                address,
                 "02-1234-5678",
                 "테스트 식당 설명",
                 LocalTime.of(10, 0),

--- a/src/test/java/com/michelet/restaurant/infrastructure/persistence/query/RestaurantQueryRepositoryImplTest.java
+++ b/src/test/java/com/michelet/restaurant/infrastructure/persistence/query/RestaurantQueryRepositoryImplTest.java
@@ -80,12 +80,11 @@ class RestaurantQueryRepositoryImplTest {
                 생성("MicheLet Bistro", RestaurantStatus.OPEN)
         );
 
-        RestaurantSearchCondition condition =
-                new RestaurantSearchCondition(
-                        "MicheLet",
-                        null,
-                        RestaurantStatus.OPEN
-                );
+        RestaurantSearchCondition condition = new RestaurantSearchCondition(
+                "MicheLet",
+                "강남구",
+                RestaurantStatus.OPEN
+        );
         PageRequest pageable = PageRequest.of(0, 1);
 
         Page<RestaurantSummaryResult> result =
@@ -96,6 +95,25 @@ class RestaurantQueryRepositoryImplTest {
         assertThat(result.getContent()).hasSize(1);
         assertThat(result.getContent().get(0).status()).isEqualTo(RestaurantStatus.OPEN);
         assertThat(result.getContent().get(0).name()).contains("MicheLet");
+    }
+
+    @Test
+    @DisplayName("지역으로 식당을 검색한다")
+    void 지역으로식당검색() {
+        RestaurantSearchCondition condition = new RestaurantSearchCondition(
+                null,
+                "강남구",
+                null
+        );
+
+        Page<RestaurantSummaryResult> result = restaurantQueryRepository.search(
+                condition,
+                PageRequest.of(0, 10)
+        );
+
+        assertThat(result.getContent())
+                .extracting(resultItem -> resultItem.address())
+                .allMatch(address -> address.contains("강남구"));
     }
 
     // 테스트용 식당 엔티티를 생성

--- a/src/test/java/com/michelet/restaurant/presentation/controller/external/RestaurantControllerTest.java
+++ b/src/test/java/com/michelet/restaurant/presentation/controller/external/RestaurantControllerTest.java
@@ -97,7 +97,8 @@ class RestaurantControllerTest {
                         LocalTime.of(10, 0),
                         90,
                         RestaurantStatus.OPEN,
-                        "MON-FRI 11:00-20:00 / SAT,SUN CLOSED"
+                        "MON-FRI 11:00-20:00 / SAT,SUN CLOSED",
+                        List.of()
                 ));
 
         mockMvc.perform(get("/api/v1/restaurants/{restaurantId}", restaurantId))

--- a/src/test/java/com/michelet/restaurant/presentation/controller/external/RestaurantControllerTest.java
+++ b/src/test/java/com/michelet/restaurant/presentation/controller/external/RestaurantControllerTest.java
@@ -167,9 +167,8 @@ class RestaurantControllerTest {
                 .andExpect(jsonPath("$.data.content[1].name").value("MicheLet Bistro"))
                 .andExpect(jsonPath("$.data.content[1].status").value("CLOSED"))
                 .andExpect(jsonPath("$.data.totalElements").value(2))
-                .andExpect(jsonPath("$.data.totalPages").value(1))
                 .andExpect(jsonPath("$.data.size").value(2))
-                .andExpect(jsonPath("$.data.number").value(0));
+                .andExpect(jsonPath("$.data.page").value(0));
     }
 
 
@@ -193,7 +192,8 @@ class RestaurantControllerTest {
                 .willReturn(new PageImpl<>(content, pageRequest, 1));
 
         mockMvc.perform(get("/api/v1/restaurants")
-                        .param("name", "MicheLet")
+                        .param("keyword", "MicheLet")
+                        .param("address", "강남구")
                         .param("status", "OPEN")
                         .param("page", "0")
                         .param("size", "10"))
@@ -203,9 +203,8 @@ class RestaurantControllerTest {
                 .andExpect(jsonPath("$.data.content[0].name").value("MicheLet Dining"))
                 .andExpect(jsonPath("$.data.content[0].status").value("OPEN"))
                 .andExpect(jsonPath("$.data.totalElements").value(1))
-                .andExpect(jsonPath("$.data.totalPages").value(1))
                 .andExpect(jsonPath("$.data.size").value(10))
-                .andExpect(jsonPath("$.data.number").value(0));
+                .andExpect(jsonPath("$.data.page").value(0));
     }
 
 

--- a/src/test/java/com/michelet/restaurant/presentation/controller/external/RestaurantControllerTest.java
+++ b/src/test/java/com/michelet/restaurant/presentation/controller/external/RestaurantControllerTest.java
@@ -9,6 +9,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.michelet.common.exception.GlobalExceptionHandler;
 import com.michelet.restaurant.application.query.RestaurantSearchCondition;
+import com.michelet.restaurant.application.result.CourseSummaryResult;
 import com.michelet.restaurant.application.result.CreateRestaurantResult;
 import com.michelet.restaurant.application.result.GetRestaurantResult;
 import com.michelet.restaurant.application.result.RestaurantSummaryResult;
@@ -16,6 +17,8 @@ import com.michelet.restaurant.application.service.command.RestaurantCommandServ
 import com.michelet.restaurant.application.service.query.RestaurantQueryService;
 import com.michelet.restaurant.domain.exception.RestaurantErrorCode;
 import com.michelet.restaurant.domain.exception.RestaurantException;
+import com.michelet.restaurant.domain.model.CourseSessionType;
+import com.michelet.restaurant.domain.model.CourseStatus;
 import com.michelet.restaurant.domain.model.RestaurantStatus;
 import java.time.LocalTime;
 import java.util.List;
@@ -85,6 +88,7 @@ class RestaurantControllerTest {
     @DisplayName("식당 상세 조회")
     void 식당상세조회() throws Exception {
         UUID restaurantId = UUID.randomUUID();
+        UUID courseId = UUID.randomUUID();
 
         given(restaurantQueryService.getRestaurant(restaurantId))
                 .willReturn(new GetRestaurantResult(
@@ -98,7 +102,16 @@ class RestaurantControllerTest {
                         90,
                         RestaurantStatus.OPEN,
                         "MON-FRI 11:00-20:00 / SAT,SUN CLOSED",
-                        List.of()
+                        List.of(
+                                new CourseSummaryResult(
+                                        courseId,
+                                        "Dinner Course",
+                                        150000L,
+                                        "애피타이저: 제철 샐러드 / 메인: 양갈비 / 디저트: 바닐라 무스",
+                                        CourseSessionType.DINNER,
+                                        CourseStatus.AVAILABLE
+                                )
+                        )
                 ));
 
         mockMvc.perform(get("/api/v1/restaurants/{restaurantId}", restaurantId))
@@ -112,7 +125,15 @@ class RestaurantControllerTest {
                 .andExpect(jsonPath("$.data.reservationOpenAt").value("10:00:00"))
                 .andExpect(jsonPath("$.data.avgMealDurationMin").value(90))
                 .andExpect(jsonPath("$.data.status").value("OPEN"))
-                .andExpect(jsonPath("$.data.businessHours").value("MON-FRI 11:00-20:00 / SAT,SUN CLOSED"));
+                .andExpect(jsonPath("$.data.businessHours").value("MON-FRI 11:00-20:00 / SAT,SUN CLOSED"))
+                .andExpect(jsonPath("$.data.courses.length()").value(1))
+                .andExpect(jsonPath("$.data.courses[0].courseId").value(courseId.toString()))
+                .andExpect(jsonPath("$.data.courses[0].name").value("Dinner Course"))
+                .andExpect(jsonPath("$.data.courses[0].price").value(150000))
+                .andExpect(jsonPath("$.data.courses[0].menuComposition")
+                        .value("애피타이저: 제철 샐러드 / 메인: 양갈비 / 디저트: 바닐라 무스"))
+                .andExpect(jsonPath("$.data.courses[0].sessionType").value("DINNER"))
+                .andExpect(jsonPath("$.data.courses[0].status").value("AVAILABLE"));
     }
 
     @Test

--- a/src/test/java/com/michelet/restaurant/presentation/controller/external/RestaurantControllerTest.java
+++ b/src/test/java/com/michelet/restaurant/presentation/controller/external/RestaurantControllerTest.java
@@ -193,7 +193,7 @@ class RestaurantControllerTest {
 
         mockMvc.perform(get("/api/v1/restaurants")
                         .param("keyword", "MicheLet")
-                        .param("address", "강남구")
+                        .param("region", "강남구")
                         .param("status", "OPEN")
                         .param("page", "0")
                         .param("size", "10"))
@@ -201,6 +201,7 @@ class RestaurantControllerTest {
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.content.length()").value(1))
                 .andExpect(jsonPath("$.data.content[0].name").value("MicheLet Dining"))
+                .andExpect(jsonPath("$.data.content[0].address").value("서울특별시 강남구 테헤란로 123"))
                 .andExpect(jsonPath("$.data.content[0].status").value("OPEN"))
                 .andExpect(jsonPath("$.data.totalElements").value(1))
                 .andExpect(jsonPath("$.data.size").value(10))

--- a/src/test/java/com/michelet/restaurant/presentation/controller/internal/RestaurantInternalControllerTest.java
+++ b/src/test/java/com/michelet/restaurant/presentation/controller/internal/RestaurantInternalControllerTest.java
@@ -12,6 +12,7 @@ import com.michelet.restaurant.domain.exception.RestaurantErrorCode;
 import com.michelet.restaurant.domain.exception.RestaurantException;
 import com.michelet.restaurant.domain.model.RestaurantStatus;
 import java.time.LocalTime;
+import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -53,7 +54,8 @@ class RestaurantInternalControllerTest {
                         LocalTime.of(10, 0),
                         90,
                         RestaurantStatus.OPEN,
-                        "MON-FRI 11:00-20:00 / SAT,SUN CLOSED"
+                        "MON-FRI 11:00-20:00 / SAT,SUN CLOSED",
+                        List.of()
                 ));
 
         mockMvc.perform(get("/internal/v1/restaurants/{restaurantId}", restaurantId))


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.

- 식당 목록/검색 조회 파라미터를 `keyword`, `region`, `status` 기준으로 정리
- `region` 검색 조건은 현재 ERD에 별도 region 컬럼이 없으므로 `address` 포함 검색으로 처리
- Spring `Page` 원본 응답을 직접 노출하지 않도록 `PageResponse` DTO를 추가
- 식당 상세 조회 응답에 코스 요약 목록 `courses[]`를 포함하도록 수정
- 코스 요약 응답은 `menuComposition` 중심으로 내려주며, 개별 `menus[]` 상세 목록은 포함하지 않음

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #15 
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to # 

## ✅ 자체 체크리스트 (필수)
- [x] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [x] Postman 테스트 완료 (인증샷 첨부)
- [x] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [x] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 Postman 실행 화면을 여기에 첨부해 주세요.

<img width="1336" height="225" alt="스크린샷 2026-04-30 141000" src="https://github.com/user-attachments/assets/d18797f3-9585-4224-be39-fb230e58d3fd" />

<img width="846" height="676" alt="스크린샷 2026-04-30 140352" src="https://github.com/user-attachments/assets/857e40e9-70be-4bd5-9495-5fc46f7543d3" />
<img width="848" height="668" alt="스크린샷 2026-04-30 140458" src="https://github.com/user-attachments/assets/004aca5b-cbe7-4b5b-a8bc-cd502b3b58bb" />
<img width="852" height="687" alt="스크린샷 2026-04-30 140530" src="https://github.com/user-attachments/assets/1428626b-9d09-4b8d-a205-8811aa8c2376" />




## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.
> - [ ] 논의점

- `region` 파라미터 값을 `address` 컬럼 포함 검색으로 처리
<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.

Issue #15


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 검색 필터가 이름 기반에서 키워드·지역 기반으로 확장되어 더 정밀한 검색 제공
  * 식당 상세 응답에 코스 목록이 포함되어 식당과 코스 정보를 한 번에 조회 가능
  * 페이지 응답 형식이 표준화되어 page, size, totalElements 등 페이징 메타데이터 제공 개선
* **테스트**
  * 검색 및 상세 조회 관련 단위/통합 테스트가 추가·갱신되어 새로운 필터와 코스 응답을 검증
<!-- end of auto-generated comment: release notes by coderabbit.ai -->