### PR TITLE
[FEAT] 식당 코스 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/michelet/restaurant/application/result/CourseListItemResult.java
+++ b/src/main/java/com/michelet/restaurant/application/result/CourseListItemResult.java
@@ -1,0 +1,38 @@
+package com.michelet.restaurant.application.result;
+
+import com.michelet.restaurant.domain.model.CourseSessionType;
+import com.michelet.restaurant.domain.model.CourseStatus;
+import com.michelet.restaurant.domain.model.RestaurantCourse;
+
+import java.util.List;
+import java.util.UUID;
+
+public record CourseListItemResult(
+        UUID courseId,
+        String name,
+        Long price,
+
+        // menus[]를 기반으로 서버가 생성해 저장한 사용자 노출용 메뉴 구성 요약 문자열
+        String menuComposition,
+
+        // 런치/디너 등 코스 제공 세션 타입
+        CourseSessionType sessionType,
+        CourseStatus status,
+
+        // 코스에 포함된 구조화된 메뉴 목록
+        List<CourseMenuResult> menus
+) {
+
+    public static CourseListItemResult of(RestaurantCourse course, List<CourseMenuResult> menus) {
+
+        return new CourseListItemResult(
+                course.getCourseId(),
+                course.getName(),
+                course.getPrice(),
+                course.getMenuComposition(),
+                course.getSessionType(),
+                course.getStatus(),
+                menus
+        );
+    }
+}

--- a/src/main/java/com/michelet/restaurant/application/result/CourseMenuResult.java
+++ b/src/main/java/com/michelet/restaurant/application/result/CourseMenuResult.java
@@ -1,0 +1,19 @@
+package com.michelet.restaurant.application.result;
+
+import com.michelet.restaurant.domain.model.CoursePart;
+import com.michelet.restaurant.domain.model.RestaurantCourseMenu;
+
+public record CourseMenuResult(
+        CoursePart coursePart,
+        String menuName,
+        Integer sortOrder
+) {
+
+    public static CourseMenuResult from(RestaurantCourseMenu menu) {
+        return new CourseMenuResult(
+                menu.getCoursePart(),
+                menu.getMenuName(),
+                menu.getSortOrder()
+        );
+    }
+}

--- a/src/main/java/com/michelet/restaurant/application/service/query/RestaurantCourseQueryService.java
+++ b/src/main/java/com/michelet/restaurant/application/service/query/RestaurantCourseQueryService.java
@@ -1,0 +1,47 @@
+package com.michelet.restaurant.application.service.query;
+
+import com.michelet.restaurant.application.result.CourseListItemResult;
+import com.michelet.restaurant.application.result.CourseMenuResult;
+import com.michelet.restaurant.domain.exception.RestaurantErrorCode;
+import com.michelet.restaurant.domain.exception.RestaurantException;
+import com.michelet.restaurant.domain.repository.RestaurantCourseMenuRepository;
+import com.michelet.restaurant.domain.repository.RestaurantCourseRepository;
+import com.michelet.restaurant.domain.repository.RestaurantRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+public class RestaurantCourseQueryService {
+
+    private final RestaurantRepository restaurantRepository;
+    private final RestaurantCourseRepository restaurantCourseRepository;
+    private final RestaurantCourseMenuRepository restaurantCourseMenuRepository;
+
+    public RestaurantCourseQueryService(RestaurantRepository restaurantRepository, RestaurantCourseRepository restaurantCourseRepository, RestaurantCourseMenuRepository restaurantCourseMenuRepository) {
+        this.restaurantRepository = restaurantRepository;
+        this.restaurantCourseRepository = restaurantCourseRepository;
+        this.restaurantCourseMenuRepository = restaurantCourseMenuRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public List<CourseListItemResult> getCourse(UUID restaurantId) {
+        restaurantRepository.findById(restaurantId)
+                .orElseThrow(() -> new RestaurantException(RestaurantErrorCode.RESTAURANT_404_NOT_FOUND));
+
+        return restaurantCourseRepository.findAllByRestaurantIdOrderByCreatedAtAsc(restaurantId)
+                .stream()
+                .map(course -> {
+                    List<CourseMenuResult> menus = restaurantCourseMenuRepository
+                            .findAllByCourseIdOrderBySortOrderAsc(course.getCourseId())
+                            .stream()
+                            .map(menu -> CourseMenuResult.from(menu))
+                            .toList();
+
+                    return CourseListItemResult.of(course, menus);
+                })
+                .toList();
+    }
+}

--- a/src/main/java/com/michelet/restaurant/application/service/query/RestaurantCourseQueryService.java
+++ b/src/main/java/com/michelet/restaurant/application/service/query/RestaurantCourseQueryService.java
@@ -27,7 +27,7 @@ public class RestaurantCourseQueryService {
     }
 
     @Transactional(readOnly = true)
-    public List<CourseListItemResult> getCourse(UUID restaurantId) {
+    public List<CourseListItemResult> getCourses(UUID restaurantId) {
         restaurantRepository.findById(restaurantId)
                 .orElseThrow(() -> new RestaurantException(RestaurantErrorCode.RESTAURANT_404_NOT_FOUND));
 

--- a/src/main/java/com/michelet/restaurant/application/service/query/RestaurantCourseQueryService.java
+++ b/src/main/java/com/michelet/restaurant/application/service/query/RestaurantCourseQueryService.java
@@ -4,6 +4,8 @@ import com.michelet.restaurant.application.result.CourseListItemResult;
 import com.michelet.restaurant.application.result.CourseMenuResult;
 import com.michelet.restaurant.domain.exception.RestaurantErrorCode;
 import com.michelet.restaurant.domain.exception.RestaurantException;
+import com.michelet.restaurant.domain.model.RestaurantCourse;
+import com.michelet.restaurant.domain.model.RestaurantCourseMenu;
 import com.michelet.restaurant.domain.repository.RestaurantCourseMenuRepository;
 import com.michelet.restaurant.domain.repository.RestaurantCourseRepository;
 import com.michelet.restaurant.domain.repository.RestaurantRepository;
@@ -11,7 +13,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Service
 public class RestaurantCourseQueryService {
@@ -28,20 +32,43 @@ public class RestaurantCourseQueryService {
 
     @Transactional(readOnly = true)
     public List<CourseListItemResult> getCourses(UUID restaurantId) {
+        // 코스 목록 조회 전에 식당 존재 여부를 먼저 검증
         restaurantRepository.findById(restaurantId)
                 .orElseThrow(() -> new RestaurantException(RestaurantErrorCode.RESTAURANT_404_NOT_FOUND));
 
-        return restaurantCourseRepository.findAllByRestaurantIdOrderByCreatedAtAsc(restaurantId)
-                .stream()
-                .map(course -> {
-                    List<CourseMenuResult> menus = restaurantCourseMenuRepository
-                            .findAllByCourseIdOrderBySortOrderAsc(course.getCourseId())
-                            .stream()
-                            .map(menu -> CourseMenuResult.from(menu))
-                            .toList();
+        // 식당에 등록된 코스 목록을 등록 순서 기준으로 조회
+        List<RestaurantCourse> courses = restaurantCourseRepository.findAllByRestaurantIdOrderByCreatedAtAsc(restaurantId);
 
-                    return CourseListItemResult.of(course, menus);
-                })
+        // 등록된 코스가 없으면 메뉴 조회를 수행하지 않고 빈 목록을 반환
+        if (courses.isEmpty()) {
+            return List.of();
+        }
+
+        // 메뉴 목록을 한 번에 조회하기 위해 courseId 목록을 추출
+        List<UUID> courseIds = courses.stream()
+                .map(course -> course.getCourseId())
+                .toList();
+
+        // courseId IN 조건으로 모든 메뉴를 한 번에 조회
+        List<RestaurantCourseMenu> courseMenus = restaurantCourseMenuRepository
+                .findAllByCourseIdInOrderByCourseIdAscSortOrderAsc(courseIds);
+
+        // 조회한 메뉴 목록을 courseId 기준으로 그룹핑
+        Map<UUID, List<CourseMenuResult>> menusByCourseId = courseMenus.stream()
+                .collect(Collectors.groupingBy(
+                        menu -> menu.getCourseId(),
+                        Collectors.mapping(
+                                menu -> CourseMenuResult.from(menu),
+                                Collectors.toList()
+                        )
+                ));
+
+        // 각 코스에 해당하는 menus[]를 붙여 외부 코스 목록 조회 결과로 변환
+        return courses.stream()
+                .map(course -> CourseListItemResult.of(
+                        course,
+                        menusByCourseId.getOrDefault(course.getCourseId(), List.of())
+                ))
                 .toList();
     }
 }

--- a/src/main/java/com/michelet/restaurant/domain/repository/RestaurantCourseMenuRepository.java
+++ b/src/main/java/com/michelet/restaurant/domain/repository/RestaurantCourseMenuRepository.java
@@ -3,9 +3,12 @@ package com.michelet.restaurant.domain.repository;
 import com.michelet.restaurant.domain.model.RestaurantCourseMenu;
 
 import java.util.List;
+import java.util.UUID;
 
 public interface RestaurantCourseMenuRepository {
 
     // 코스에 포함된 메뉴 목록을 한 번에 저장
     List<RestaurantCourseMenu> saveAll(List<RestaurantCourseMenu> restaurantCourseMenus);
+
+    List<RestaurantCourseMenu> findAllByCourseIdOrderBySortOrderAsc(UUID courseId);
 }

--- a/src/main/java/com/michelet/restaurant/domain/repository/RestaurantCourseMenuRepository.java
+++ b/src/main/java/com/michelet/restaurant/domain/repository/RestaurantCourseMenuRepository.java
@@ -9,6 +9,8 @@ public interface RestaurantCourseMenuRepository {
 
     // 코스에 포함된 메뉴 목록을 한 번에 저장
     List<RestaurantCourseMenu> saveAll(List<RestaurantCourseMenu> restaurantCourseMenus);
-
+    // 코스 ID 기준으로 코스 메뉴 목록을 조회
     List<RestaurantCourseMenu> findAllByCourseIdOrderBySortOrderAsc(UUID courseId);
+    // 여러 코스 ID 기준으로 코스 메뉴 목록을 한 번에 조회
+    List<RestaurantCourseMenu> findAllByCourseIdInOrderByCourseIdAscSortOrderAsc(List<UUID> courseIds);
 }

--- a/src/main/java/com/michelet/restaurant/infrastructure/persistence/RestaurantCourseMenuJpaRepository.java
+++ b/src/main/java/com/michelet/restaurant/infrastructure/persistence/RestaurantCourseMenuJpaRepository.java
@@ -16,4 +16,12 @@ public interface RestaurantCourseMenuJpaRepository extends JpaRepository<Restaur
      * sortOrder 오름차순으로 정렬된 코스 메뉴 목록
      */
     List<RestaurantCourseMenu> findAllByCourseIdOrderBySortOrderAsc(UUID courseId);
+
+    /**
+     * 여러 코스 ID 기준으로 코스 메뉴 목록을 한 번에 조회
+     *
+     * 코스마다 메뉴를 개별 조회하면 N+1 문제가 발생
+     * courseId IN 조건으로 메뉴 목록을 한 번에 조회
+     */
+    List<RestaurantCourseMenu> findAllByCourseIdInOrderByCourseIdAscSortOrderAsc(List<UUID> courseIds);
 }

--- a/src/main/java/com/michelet/restaurant/infrastructure/persistence/RestaurantCourseMenuJpaRepository.java
+++ b/src/main/java/com/michelet/restaurant/infrastructure/persistence/RestaurantCourseMenuJpaRepository.java
@@ -3,11 +3,17 @@ package com.michelet.restaurant.infrastructure.persistence;
 import com.michelet.restaurant.domain.model.RestaurantCourseMenu;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface RestaurantCourseMenuJpaRepository extends JpaRepository<RestaurantCourseMenu, UUID> {
 
-    // 현재 Issue #11 범위는 코스 등록
-    // 등록에는 JpaRepository 기본 saveAll 메서드만 필요하므로 별도 조회 메서드는 추가x
-
+    /**
+     * 코스 ID 기준으로 코스 메뉴 목록을 조회
+     *
+     * 메뉴 노출 순서는 클라이언트 요청 순서가 아니라 sortOrder 기준
+     * courseId 메뉴 목록을 조회할 코스 ID
+     * sortOrder 오름차순으로 정렬된 코스 메뉴 목록
+     */
+    List<RestaurantCourseMenu> findAllByCourseIdOrderBySortOrderAsc(UUID courseId);
 }

--- a/src/main/java/com/michelet/restaurant/infrastructure/persistence/RestaurantCourseMenuRepositoryImpl.java
+++ b/src/main/java/com/michelet/restaurant/infrastructure/persistence/RestaurantCourseMenuRepositoryImpl.java
@@ -27,4 +27,10 @@ public class RestaurantCourseMenuRepositoryImpl implements RestaurantCourseMenuR
     public List<RestaurantCourseMenu> findAllByCourseIdOrderBySortOrderAsc(UUID courseId) {
         return restaurantCourseMenuJpaRepository.findAllByCourseIdOrderBySortOrderAsc(courseId);
     }
+
+    // 여러 코스 ID 기준으로 코스 메뉴 목록을 한 번에 조회
+    @Override
+    public List<RestaurantCourseMenu> findAllByCourseIdInOrderByCourseIdAscSortOrderAsc(List<UUID> courseIds) {
+        return restaurantCourseMenuJpaRepository.findAllByCourseIdInOrderByCourseIdAscSortOrderAsc(courseIds);
+    }
 }

--- a/src/main/java/com/michelet/restaurant/infrastructure/persistence/RestaurantCourseMenuRepositoryImpl.java
+++ b/src/main/java/com/michelet/restaurant/infrastructure/persistence/RestaurantCourseMenuRepositoryImpl.java
@@ -5,6 +5,7 @@ import com.michelet.restaurant.domain.repository.RestaurantCourseMenuRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.UUID;
 
 @Repository
 public class RestaurantCourseMenuRepositoryImpl implements RestaurantCourseMenuRepository {
@@ -15,8 +16,15 @@ public class RestaurantCourseMenuRepositoryImpl implements RestaurantCourseMenuR
         this.restaurantCourseMenuJpaRepository = restaurantCourseMenuJpaRepository;
     }
 
+    // 코스 등록 시 여러 코스 메뉴를 한 번에 저장
     @Override
     public List<RestaurantCourseMenu> saveAll(List<RestaurantCourseMenu> restaurantCourseMenus) {
         return restaurantCourseMenuJpaRepository.saveAll(restaurantCourseMenus);
+    }
+
+    // 코스 ID 기준으로 코스 메뉴 목록을 조회
+    @Override
+    public List<RestaurantCourseMenu> findAllByCourseIdOrderBySortOrderAsc(UUID courseId) {
+        return restaurantCourseMenuJpaRepository.findAllByCourseIdOrderBySortOrderAsc(courseId);
     }
 }

--- a/src/main/java/com/michelet/restaurant/presentation/controller/external/RestaurantCourseController.java
+++ b/src/main/java/com/michelet/restaurant/presentation/controller/external/RestaurantCourseController.java
@@ -2,13 +2,17 @@ package com.michelet.restaurant.presentation.controller.external;
 
 import com.michelet.common.response.ApiResponse;
 import com.michelet.restaurant.application.command.CreateCourseCommand;
+import com.michelet.restaurant.application.result.CourseListItemResult;
 import com.michelet.restaurant.application.result.CourseResult;
 import com.michelet.restaurant.application.service.command.RestaurantCourseCommandService;
+import com.michelet.restaurant.application.service.query.RestaurantCourseQueryService;
+import com.michelet.restaurant.presentation.dto.CourseListItemResponse;
 import com.michelet.restaurant.presentation.dto.CourseResponse;
 import com.michelet.restaurant.presentation.dto.CreateCourseRequest;
 import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.UUID;
 
 @RestController
@@ -16,9 +20,11 @@ import java.util.UUID;
 public class RestaurantCourseController {
 
     private final RestaurantCourseCommandService restaurantCourseCommandService;
+    private final RestaurantCourseQueryService restaurantCourseQueryService;
 
-    public RestaurantCourseController(RestaurantCourseCommandService restaurantCourseCommandService) {
+    public RestaurantCourseController(RestaurantCourseCommandService restaurantCourseCommandService, RestaurantCourseQueryService restaurantCourseQueryService) {
         this.restaurantCourseCommandService = restaurantCourseCommandService;
+        this.restaurantCourseQueryService = restaurantCourseQueryService;
     }
 
     @PostMapping
@@ -34,5 +40,21 @@ public class RestaurantCourseController {
                         result.restaurantId()
                 )
         );
+    }
+
+    /**
+     * 식당 ID 기준으로 외부 코스 목록을 조회
+     * 외부 코스 목록 조회 응답은 코스 요약 정보와 menus[]를 함께 포함
+     */
+    @GetMapping
+    public ApiResponse<List<CourseListItemResponse>> getCourses(@PathVariable UUID restaurantId) {
+
+        List<CourseListItemResult> results = restaurantCourseQueryService.getCourses(restaurantId);
+
+        List<CourseListItemResponse> responses = results.stream()
+                .map(result -> CourseListItemResponse.from(result))
+                .toList();
+
+        return ApiResponse.ok(responses);
     }
 }

--- a/src/main/java/com/michelet/restaurant/presentation/dto/CourseListItemResponse.java
+++ b/src/main/java/com/michelet/restaurant/presentation/dto/CourseListItemResponse.java
@@ -1,0 +1,34 @@
+package com.michelet.restaurant.presentation.dto;
+
+import com.michelet.restaurant.application.result.CourseListItemResult;
+import com.michelet.restaurant.domain.model.CourseSessionType;
+import com.michelet.restaurant.domain.model.CourseStatus;
+
+import java.util.List;
+import java.util.UUID;
+
+public record CourseListItemResponse(
+        UUID courseId,
+        String name,
+        Long price,
+        String menuComposition,
+        CourseSessionType sessionType,
+        CourseStatus status,
+        // 코스에 포함된 구조화된 메뉴 목록
+        List<CourseMenuResponse> menus
+) {
+
+    public static CourseListItemResponse from(CourseListItemResult result) {
+        return new CourseListItemResponse(
+                result.courseId(),
+                result.name(),
+                result.price(),
+                result.menuComposition(),
+                result.sessionType(),
+                result.status(),
+                result.menus().stream()
+                        .map(menu -> CourseMenuResponse.from(menu))
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/com/michelet/restaurant/presentation/dto/CourseMenuResponse.java
+++ b/src/main/java/com/michelet/restaurant/presentation/dto/CourseMenuResponse.java
@@ -1,0 +1,22 @@
+package com.michelet.restaurant.presentation.dto;
+
+import com.michelet.restaurant.application.result.CourseMenuResult;
+import com.michelet.restaurant.domain.model.CoursePart;
+
+public record CourseMenuResponse(
+        // 코스 구성 구간(AMUSE_BOUCHE, APPETIZER, FISH, MAIN, DESSERT)
+        CoursePart coursePart,
+        // 메뉴명
+        String menuName,
+        // 코스 내 노출 순서
+        Integer sortOrder
+) {
+
+    public static CourseMenuResponse from(CourseMenuResult result) {
+        return new CourseMenuResponse(
+                result.coursePart(),
+                result.menuName(),
+                result.sortOrder()
+        );
+    }
+}

--- a/src/test/http/restaurant-course-api.http
+++ b/src/test/http/restaurant-course-api.http
@@ -1,0 +1,77 @@
+### 공통 변수
+### 현재 인증/인가 미구현 상태이므로 X-User-Id로 임시 사용자 식별
+### 추후 JWT 적용 시 Authorization 헤더로 변경 예정
+@baseUrl = http://localhost:19300
+@ownerId = 11111111-1111-1111-1111-111111111111
+
+
+### 1. 식당 등록
+POST {{baseUrl}}/api/v1/restaurants
+Content-Type: application/json
+X-User-Id: {{ownerId}}
+
+{
+  "name": "MicheLet Dining",
+  "address": "서울특별시 강남구 테헤란로 123",
+  "phone": "02-1234-5678",
+  "description": "파인다이닝 레스토랑",
+  "reservationOpenAt": "10:00:00",
+  "avgMealDurationMin": 90,
+  "status": "OPEN",
+  "businessHours": "MON-FRI 11:00-20:00 / SAT,SUN CLOSED"
+}
+
+> {%
+    client.global.set("restaurantId", response.body.data.restaurantId);
+%}
+
+
+### 2. 코스 등록
+POST {{baseUrl}}/api/v1/restaurants/{{restaurantId}}/courses
+Content-Type: application/json
+
+{
+  "name": "Dinner Course",
+  "price": 150000,
+  "sessionType": "DINNER",
+  "status": "AVAILABLE",
+  "menus": [
+    {
+      "coursePart": "MAIN",
+      "menuName": "양갈비",
+      "sortOrder": 4
+    },
+    {
+      "coursePart": "AMUSE_BOUCHE",
+      "menuName": "한우 타르타르",
+      "sortOrder": 1
+    },
+    {
+      "coursePart": "APPETIZER",
+      "menuName": "제철 샐러드",
+      "sortOrder": 2
+    },
+    {
+      "coursePart": "FISH",
+      "menuName": "제철 생선 구이",
+      "sortOrder": 3
+    },
+    {
+      "coursePart": "DESSERT",
+      "menuName": "바닐라 무스",
+      "sortOrder": 5
+    }
+  ]
+}
+
+> {%
+    client.global.set("courseId", response.body.data.courseId);
+%}
+
+
+### 3. 코스 목록 조회
+GET {{baseUrl}}/api/v1/restaurants/{{restaurantId}}/courses
+
+
+### 4. 존재하지 않는 식당의 코스 목록 조회 - 404 확인
+GET {{baseUrl}}/api/v1/restaurants/00000000-0000-0000-0000-000000000000/courses

--- a/src/test/java/com/michelet/restaurant/application/service/query/RestaurantCourseQueryServiceTest.java
+++ b/src/test/java/com/michelet/restaurant/application/service/query/RestaurantCourseQueryServiceTest.java
@@ -1,0 +1,200 @@
+package com.michelet.restaurant.application.service.query;
+
+
+import com.michelet.restaurant.application.result.CourseListItemResult;
+import com.michelet.restaurant.domain.model.CoursePart;
+import com.michelet.restaurant.domain.model.CourseSessionType;
+import com.michelet.restaurant.domain.model.CourseStatus;
+import com.michelet.restaurant.domain.model.Restaurant;
+import com.michelet.restaurant.domain.model.RestaurantCourse;
+import com.michelet.restaurant.domain.model.RestaurantCourseMenu;
+import com.michelet.restaurant.domain.model.RestaurantStatus;
+import com.michelet.restaurant.domain.repository.RestaurantCourseMenuRepository;
+import com.michelet.restaurant.domain.repository.RestaurantCourseRepository;
+import com.michelet.restaurant.domain.repository.RestaurantRepository;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class RestaurantCourseQueryServiceTest {
+
+    @InjectMocks
+    private RestaurantCourseQueryService restaurantCourseQueryService;
+
+    @Mock
+    private RestaurantRepository restaurantRepository;
+
+    @Mock
+    private RestaurantCourseRepository restaurantCourseRepository;
+
+    @Mock
+    private RestaurantCourseMenuRepository restaurantCourseMenuRepository;
+
+    @Test
+    @DisplayName("코스 목록 조회")
+    void 코스목록조회() {
+        UUID restaurantId = UUID.randomUUID();
+
+        Restaurant restaurant = Restaurant.create(
+                UUID.randomUUID(),
+                "MicheLet Dining",
+                "서울특별시 강남구 테헤란로 123",
+                "02-1234-5678",
+                "파인다이닝 레스토랑",
+                LocalTime.of(10, 0),
+                90,
+                RestaurantStatus.OPEN,
+                "MON-FRI 11:00-20:00 / SAT,SUN CLOSED"
+        );
+        ReflectionTestUtils.setField(restaurant, "restaurantId", restaurantId);
+
+        RestaurantCourse dinnerCourse = RestaurantCourse.create(
+                restaurantId,
+                "Dinner Course",
+                150000L,
+                "아뮤즈 부쉬: 한우 타르타르 / 애피타이저: 제철 샐러드 / 메인: 양갈비",
+                CourseSessionType.DINNER,
+                CourseStatus.AVAILABLE
+        );
+
+        RestaurantCourse lunchCourse = RestaurantCourse.create(
+                restaurantId,
+                "Lunch Course",
+                90000L,
+                "애피타이저: 제철 샐러드 / 메인: 광어구이",
+                CourseSessionType.LUNCH,
+                CourseStatus.AVAILABLE
+        );
+
+        RestaurantCourseMenu dinnerMenu1 = RestaurantCourseMenu.create(
+                dinnerCourse.getCourseId(),
+                CoursePart.AMUSE_BOUCHE,
+                "한우 타르타르",
+                1
+        );
+
+        RestaurantCourseMenu dinnerMenu2 = RestaurantCourseMenu.create(
+                dinnerCourse.getCourseId(),
+                CoursePart.APPETIZER,
+                "제철 샐러드",
+                2
+        );
+
+        RestaurantCourseMenu dinnerMenu3 = RestaurantCourseMenu.create(
+                dinnerCourse.getCourseId(),
+                CoursePart.MAIN,
+                "양갈비",
+                3
+        );
+
+        RestaurantCourseMenu lunchMenu1 = RestaurantCourseMenu.create(
+                lunchCourse.getCourseId(),
+                CoursePart.APPETIZER,
+                "제철 샐러드",
+                1
+        );
+
+        RestaurantCourseMenu lunchMenu2 = RestaurantCourseMenu.create(
+                lunchCourse.getCourseId(),
+                CoursePart.FISH,
+                "광어구이",
+                2
+        );
+
+        List<UUID> courseIds = List.of(
+                dinnerCourse.getCourseId(),
+                lunchCourse.getCourseId()
+        );
+
+        given(restaurantRepository.findById(restaurantId))
+                .willReturn(Optional.of(restaurant));
+
+        given(restaurantCourseRepository.findAllByRestaurantIdOrderByCreatedAtAsc(restaurantId))
+                .willReturn(List.of(dinnerCourse, lunchCourse));
+
+        given(restaurantCourseMenuRepository.findAllByCourseIdInOrderByCourseIdAscSortOrderAsc(courseIds))
+                .willReturn(List.of(
+                        dinnerMenu1,
+                        dinnerMenu2,
+                        dinnerMenu3,
+                        lunchMenu1,
+                        lunchMenu2
+                ));
+
+        List<CourseListItemResult> results = restaurantCourseQueryService.getCourses(restaurantId);
+
+        assertThat(results).hasSize(2);
+
+        CourseListItemResult dinnerResult = results.get(0);
+        assertThat(dinnerResult.courseId()).isEqualTo(dinnerCourse.getCourseId());
+        assertThat(dinnerResult.name()).isEqualTo("Dinner Course");
+        assertThat(dinnerResult.price()).isEqualTo(150000L);
+        assertThat(dinnerResult.menuComposition())
+                .isEqualTo("아뮤즈 부쉬: 한우 타르타르 / 애피타이저: 제철 샐러드 / 메인: 양갈비");
+        assertThat(dinnerResult.sessionType()).isEqualTo(CourseSessionType.DINNER);
+        assertThat(dinnerResult.status()).isEqualTo(CourseStatus.AVAILABLE);
+        assertThat(dinnerResult.menus()).hasSize(3);
+        assertThat(dinnerResult.menus().get(0).coursePart()).isEqualTo(CoursePart.AMUSE_BOUCHE);
+        assertThat(dinnerResult.menus().get(0).menuName()).isEqualTo("한우 타르타르");
+        assertThat(dinnerResult.menus().get(0).sortOrder()).isEqualTo(1);
+
+        CourseListItemResult lunchResult = results.get(1);
+        assertThat(lunchResult.courseId()).isEqualTo(lunchCourse.getCourseId());
+        assertThat(lunchResult.name()).isEqualTo("Lunch Course");
+        assertThat(lunchResult.price()).isEqualTo(90000L);
+        assertThat(lunchResult.menuComposition())
+                .isEqualTo("애피타이저: 제철 샐러드 / 메인: 광어구이");
+        assertThat(lunchResult.sessionType()).isEqualTo(CourseSessionType.LUNCH);
+        assertThat(lunchResult.status()).isEqualTo(CourseStatus.AVAILABLE);
+        assertThat(lunchResult.menus()).hasSize(2);
+        assertThat(lunchResult.menus().get(0).coursePart()).isEqualTo(CoursePart.APPETIZER);
+        assertThat(lunchResult.menus().get(0).menuName()).isEqualTo("제철 샐러드");
+        assertThat(lunchResult.menus().get(0).sortOrder()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("코스가 없으면 빈 목록 반환")
+    void 코스가없으면_빈목록반환() {
+        UUID restaurantId = UUID.randomUUID();
+
+        Restaurant restaurant = Restaurant.create(
+                UUID.randomUUID(),
+                "MicheLet Dining",
+                "서울특별시 강남구 테헤란로 123",
+                "02-1234-5678",
+                "파인다이닝 레스토랑",
+                LocalTime.of(10, 0),
+                90,
+                RestaurantStatus.OPEN,
+                "MON-FRI 11:00-20:00 / SAT,SUN CLOSED"
+        );
+        ReflectionTestUtils.setField(restaurant, "restaurantId", restaurantId);
+
+        given(restaurantRepository.findById(restaurantId))
+                .willReturn(Optional.of(restaurant));
+
+        given(restaurantCourseRepository.findAllByRestaurantIdOrderByCreatedAtAsc(restaurantId))
+                .willReturn(List.of());
+
+        List<CourseListItemResult> results = restaurantCourseQueryService.getCourses(restaurantId);
+
+        assertThat(results).isEmpty();
+
+        verify(restaurantCourseMenuRepository, never())
+                .findAllByCourseIdInOrderByCourseIdAscSortOrderAsc(List.of());
+    }
+}

--- a/src/test/java/com/michelet/restaurant/presentation/controller/external/RestaurantCourseControllerTest.java
+++ b/src/test/java/com/michelet/restaurant/presentation/controller/external/RestaurantCourseControllerTest.java
@@ -1,0 +1,107 @@
+package com.michelet.restaurant.presentation.controller.external;
+
+
+import com.michelet.common.exception.GlobalExceptionHandler;
+import com.michelet.restaurant.application.result.CourseListItemResult;
+import com.michelet.restaurant.application.result.CourseMenuResult;
+import com.michelet.restaurant.application.service.command.RestaurantCourseCommandService;
+import com.michelet.restaurant.application.service.query.RestaurantCourseQueryService;
+import com.michelet.restaurant.domain.model.CoursePart;
+import com.michelet.restaurant.domain.model.CourseSessionType;
+import com.michelet.restaurant.domain.model.CourseStatus;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(RestaurantCourseController.class)
+@Import(GlobalExceptionHandler.class)
+class RestaurantCourseControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private RestaurantCourseCommandService restaurantCourseCommandService;
+
+    @MockitoBean
+    private RestaurantCourseQueryService restaurantCourseQueryService;
+
+    @Test
+    @DisplayName("코스 목록 조회")
+    void 코스목록조회() throws Exception {
+        UUID restaurantId = UUID.randomUUID();
+        UUID courseId = UUID.randomUUID();
+
+        given(restaurantCourseQueryService.getCourses(restaurantId))
+                .willReturn(List.of(
+                        new CourseListItemResult(
+                                courseId,
+                                "Dinner Course",
+                                150000L,
+                                "아뮤즈 부쉬: 한우 타르타르 / 애피타이저: 제철 샐러드 / 생선: 제철 생선 구이 / 메인: 양갈비 / 디저트: 바닐라 무스",
+                                CourseSessionType.DINNER,
+                                CourseStatus.AVAILABLE,
+                                List.of(
+                                        new CourseMenuResult(
+                                                CoursePart.AMUSE_BOUCHE,
+                                                "한우 타르타르",
+                                                1
+                                        ),
+                                        new CourseMenuResult(
+                                                CoursePart.APPETIZER,
+                                                "제철 샐러드",
+                                                2
+                                        ),
+                                        new CourseMenuResult(
+                                                CoursePart.FISH,
+                                                "제철 생선 구이",
+                                                3
+                                        ),
+                                        new CourseMenuResult(
+                                                CoursePart.MAIN,
+                                                "양갈비",
+                                                4
+                                        ),
+                                        new CourseMenuResult(
+                                                CoursePart.DESSERT,
+                                                "바닐라 무스",
+                                                5
+                                        )
+                                )
+                        )
+                ));
+
+        mockMvc.perform(get("/api/v1/restaurants/{restaurantId}/courses", restaurantId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.length()").value(1))
+                .andExpect(jsonPath("$.data[0].courseId").value(courseId.toString()))
+                .andExpect(jsonPath("$.data[0].name").value("Dinner Course"))
+                .andExpect(jsonPath("$.data[0].price").value(150000))
+                .andExpect(jsonPath("$.data[0].menuComposition")
+                        .value("아뮤즈 부쉬: 한우 타르타르 / 애피타이저: 제철 샐러드 / 생선: 제철 생선 구이 / 메인: 양갈비 / 디저트: 바닐라 무스"))
+                .andExpect(jsonPath("$.data[0].sessionType").value("DINNER"))
+                .andExpect(jsonPath("$.data[0].status").value("AVAILABLE"))
+                .andExpect(jsonPath("$.data[0].menus.length()").value(5))
+                .andExpect(jsonPath("$.data[0].menus[0].coursePart").value("AMUSE_BOUCHE"))
+                .andExpect(jsonPath("$.data[0].menus[0].menuName").value("한우 타르타르"))
+                .andExpect(jsonPath("$.data[0].menus[0].sortOrder").value(1))
+                .andExpect(jsonPath("$.data[0].menus[1].coursePart").value("APPETIZER"))
+                .andExpect(jsonPath("$.data[0].menus[1].menuName").value("제철 샐러드"))
+                .andExpect(jsonPath("$.data[0].menus[1].sortOrder").value(2))
+                .andExpect(jsonPath("$.data[0].menus[4].coursePart").value("DESSERT"))
+                .andExpect(jsonPath("$.data[0].menus[4].menuName").value("바닐라 무스"))
+                .andExpect(jsonPath("$.data[0].menus[4].sortOrder").value(5));
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.

- 식당별 코스 목록 조회 API를 구현

- 특정 식당 ID를 기준으로 등록된 코스 목록을 조회하고, 외부 응답에는 코스 기본 정보와 함께 `menus[]`를 포함하도록 구현

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #17 
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to # 

## ✅ 자체 체크리스트 (필수)
- [x] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [x] IntelliJ HTTP Client 수동 테스트 파일 추가
- [x] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [x] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 Postman 실행 화면을 여기에 첨부해 주세요.

<img width="1542" height="223" alt="스크린샷 2026-05-01 011529" src="https://github.com/user-attachments/assets/ea6e512f-be38-4e9f-87dc-a5c80ae70b4c" />
<img width="1878" height="976" alt="스크린샷 2026-05-01 011331" src="https://github.com/user-attachments/assets/de8f9411-943b-4b7a-a4ee-8260e3cc109f" />
<img width="1884" height="988" alt="스크린샷 2026-05-01 011346" src="https://github.com/user-attachments/assets/9abb0a04-5f6a-4bb4-a966-a4848907d686" />


## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.
> - [ ] 논의점

- 외부 코스 목록 조회 응답은 MVP 명세에 맞춰 `data`를 배열로 반환
- 외부 코스 목록 조회에는 `menus[]`를 포함
- `menuComposition`은 코스 등록 시 서버가 `menus[]`를 기반으로 생성해 저장한 사용자 노출용 요약 문자열
- 코스 메뉴 조회는 코스마다 개별 조회하지 않고, `courseId IN` 조건으로 한 번에 조회한 뒤 `courseId` 기준으로 그룹핑
- 이번 PR은 외부 코스 목록 조회 API까지만 포함
- 내부 코스 목록 조회 API(`/internal/v1/restaurants/{restaurantId}/courses`)는 별도 이슈에서 처리할 예정

<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 레스토랑의 코스 목록 조회 기능 추가
  * 코스별 상세 정보(이름, 가격, 세션 타입, 상태) 및 관련 메뉴 조회 가능
  * GET `/api/v1/restaurants/{restaurantId}/courses` 엔드포인트를 통해 코스 목록 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->