### PR TITLE
Feat/19 internal course list api

### DIFF
--- a/src/main/java/com/michelet/restaurant/application/service/query/RestaurantCourseQueryService.java
+++ b/src/main/java/com/michelet/restaurant/application/service/query/RestaurantCourseQueryService.java
@@ -73,6 +73,7 @@ public class RestaurantCourseQueryService {
                 .toList();
     }
 
+    // 식당 ID 기준으로 내부 코스 목록을 조회
     @Transactional(readOnly = true)
     public List<CourseSummaryResult> getInternalCourses(UUID restaurantId) {
         restaurantRepository.findById(restaurantId)

--- a/src/main/java/com/michelet/restaurant/application/service/query/RestaurantCourseQueryService.java
+++ b/src/main/java/com/michelet/restaurant/application/service/query/RestaurantCourseQueryService.java
@@ -2,6 +2,7 @@ package com.michelet.restaurant.application.service.query;
 
 import com.michelet.restaurant.application.result.CourseListItemResult;
 import com.michelet.restaurant.application.result.CourseMenuResult;
+import com.michelet.restaurant.application.result.CourseSummaryResult;
 import com.michelet.restaurant.domain.exception.RestaurantErrorCode;
 import com.michelet.restaurant.domain.exception.RestaurantException;
 import com.michelet.restaurant.domain.model.RestaurantCourse;
@@ -69,6 +70,17 @@ public class RestaurantCourseQueryService {
                         course,
                         menusByCourseId.getOrDefault(course.getCourseId(), List.of())
                 ))
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<CourseSummaryResult> getInternalCourses(UUID restaurantId) {
+        restaurantRepository.findById(restaurantId)
+                .orElseThrow(() -> new RestaurantException(RestaurantErrorCode.RESTAURANT_404_NOT_FOUND));
+
+        return restaurantCourseRepository.findAllByRestaurantIdOrderByCreatedAtAsc(restaurantId)
+                .stream()
+                .map(course -> CourseSummaryResult.from(course))
                 .toList();
     }
 }

--- a/src/main/java/com/michelet/restaurant/presentation/controller/internal/RestaurantCourseInternalController.java
+++ b/src/main/java/com/michelet/restaurant/presentation/controller/internal/RestaurantCourseInternalController.java
@@ -1,0 +1,37 @@
+package com.michelet.restaurant.presentation.controller.internal;
+
+import com.michelet.common.response.ApiResponse;
+import com.michelet.restaurant.application.result.CourseSummaryResult;
+import com.michelet.restaurant.application.service.query.RestaurantCourseQueryService;
+import com.michelet.restaurant.presentation.dto.CourseSummaryResponse;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/internal/v1/restaurants/{restaurantId}/courses")
+public class RestaurantCourseInternalController {
+
+    private final RestaurantCourseQueryService restaurantCourseQueryService;
+
+    public RestaurantCourseInternalController(RestaurantCourseQueryService restaurantCourseQueryService) {
+        this.restaurantCourseQueryService = restaurantCourseQueryService;
+    }
+
+    // 식당 ID 기준으로 내부 코스 목록을 조회
+    @GetMapping
+    public ApiResponse<List<CourseSummaryResponse>> getInternalCourses(@PathVariable UUID restaurantId) {
+
+        List<CourseSummaryResult> results = restaurantCourseQueryService.getInternalCourses(restaurantId);
+
+        List<CourseSummaryResponse> responses = results.stream()
+                .map(result -> CourseSummaryResponse.from(result))
+                .toList();
+
+        return ApiResponse.ok(responses);
+    }
+}

--- a/src/test/http/restaurant-course-api.http
+++ b/src/test/http/restaurant-course-api.http
@@ -75,3 +75,13 @@ GET {{baseUrl}}/api/v1/restaurants/{{restaurantId}}/courses
 
 ### 4. 존재하지 않는 식당의 코스 목록 조회 - 404 확인
 GET {{baseUrl}}/api/v1/restaurants/00000000-0000-0000-0000-000000000000/courses
+
+
+### 5. 내부 코스 목록 조회
+GET {{baseUrl}}/internal/v1/restaurants/{{restaurantId}}/courses
+X-Internal-Request: true
+
+
+### 6. 존재하지 않는 식당의 내부 코스 목록 조회 - 404 확인
+GET {{baseUrl}}/internal/v1/restaurants/00000000-0000-0000-0000-000000000000/courses
+X-Internal-Request: true

--- a/src/test/java/com/michelet/restaurant/presentation/controller/internal/RestaurantCourseInternalControllerTest.java
+++ b/src/test/java/com/michelet/restaurant/presentation/controller/internal/RestaurantCourseInternalControllerTest.java
@@ -1,0 +1,80 @@
+package com.michelet.restaurant.presentation.controller.internal;
+
+
+import com.michelet.common.exception.GlobalExceptionHandler;
+import com.michelet.restaurant.application.result.CourseSummaryResult;
+import com.michelet.restaurant.application.service.query.RestaurantCourseQueryService;
+import com.michelet.restaurant.domain.exception.RestaurantErrorCode;
+import com.michelet.restaurant.domain.exception.RestaurantException;
+import com.michelet.restaurant.domain.model.CourseSessionType;
+import com.michelet.restaurant.domain.model.CourseStatus;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(RestaurantCourseInternalController.class)
+@Import(GlobalExceptionHandler.class)
+class RestaurantCourseInternalControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private RestaurantCourseQueryService restaurantCourseQueryService;
+
+    @Test
+    @DisplayName("내부 코스 목록 조회")
+    void 내부코스목록조회() throws Exception {
+        UUID restaurantId = UUID.randomUUID();
+        UUID courseId = UUID.randomUUID();
+
+        given(restaurantCourseQueryService.getInternalCourses(restaurantId))
+                .willReturn(List.of(
+                        new CourseSummaryResult(
+                                courseId,
+                                "Dinner Course",
+                                150000L,
+                                "아뮤즈 부쉬: 한우 타르타르 / 애피타이저: 제철 샐러드 / 생선: 제철 생선 구이 / 메인: 양갈비 / 디저트: 바닐라 무스",
+                                CourseSessionType.DINNER,
+                                CourseStatus.AVAILABLE
+                        )
+                ));
+
+        mockMvc.perform(get("/internal/v1/restaurants/{restaurantId}/courses", restaurantId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.length()").value(1))
+                .andExpect(jsonPath("$.data[0].courseId").value(courseId.toString()))
+                .andExpect(jsonPath("$.data[0].name").value("Dinner Course"))
+                .andExpect(jsonPath("$.data[0].price").value(150000))
+                .andExpect(jsonPath("$.data[0].menuComposition")
+                        .value("아뮤즈 부쉬: 한우 타르타르 / 애피타이저: 제철 샐러드 / 생선: 제철 생선 구이 / 메인: 양갈비 / 디저트: 바닐라 무스"))
+                .andExpect(jsonPath("$.data[0].sessionType").value("DINNER"))
+                .andExpect(jsonPath("$.data[0].status").value("AVAILABLE"))
+                .andExpect(jsonPath("$.data[0].menus").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 식당의 내부 코스 목록 조회")
+    void 존재하지않는식당의_내부코스목록조회() throws Exception {
+        UUID restaurantId = UUID.fromString("00000000-0000-0000-0000-000000000000");
+
+        given(restaurantCourseQueryService.getInternalCourses(restaurantId))
+                .willThrow(new RestaurantException(RestaurantErrorCode.RESTAURANT_404_NOT_FOUND));
+
+        mockMvc.perform(get("/internal/v1/restaurants/{restaurantId}/courses", restaurantId))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.success").value(false));
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.

- restaurant-service에 내부 코스 목록 조회 API를 추가
- 다른 서비스에서 특정 식당의 코스 목록을 경량으로 조회할 수 있도록 `GET /internal/v1/restaurants/{restaurantId}/courses` API를 구현
- 외부 코스 목록 조회 API와 달리 내부 API 응답에서는 `menus[]`를 제외하고, `menuComposition` 중심의 코스 요약 정보만 반환하도록 구성

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #19 
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to # 

## ✅ 자체 체크리스트 (필수)
- [x] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [x] IntelliJ HTTP Client 수동 테스트 완료
- [x] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [x] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 Postman 실행 화면을 여기에 첨부해 주세요.

<img width="1430" height="223" alt="스크린샷 2026-05-01 021834" src="https://github.com/user-attachments/assets/b5f66efa-860e-481d-ad52-880b8665bb42" />
<img width="1916" height="982" alt="스크린샷 2026-05-01 021524" src="https://github.com/user-attachments/assets/b3b88cfd-73ce-49a5-bb73-832a80d82687" />
<img width="1919" height="991" alt="스크린샷 2026-05-01 021532" src="https://github.com/user-attachments/assets/d2fb6d47-e4d7-41ce-81a7-764bf80c09a1" />


## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.
> - [ ] 논의점

- 내부 코스 목록 조회 API는 다른 서비스에서 사용할 경량 조회 API
- 외부 코스 목록 조회 API와 달리 내부 API에서는 `menus[]`를 포함하지 않음
- 응답의 `menuComposition`은 코스 등록 시 서버가 `menus[]`를 기반으로 생성해 저장한 사용자 노출용 요약 문자열
 
<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 레스토랑별 코스 목록 조회를 위한 내부 API 엔드포인트 추가
  * 존재하지 않는 레스토랑에 대한 오류 처리 포함

* **Tests**
  * 내부 API 엔드포인트에 대한 단위 테스트 추가
  * 정상 조회 및 오류 응답 시나리오 검증

<!-- end of auto-generated comment: release notes by coderabbit.ai -->