### PR TITLE
[FEAT] 식당 체크인 처리 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
     implementation 'com.github.Miche-Let:common:dev-SNAPSHOT'
     implementation 'com.github.Miche-Let:common-auth-webmvc:0.1.3'
+    implementation 'io.github.openfeign:feign-hc5'
 
     runtimeOnly 'org.postgresql:postgresql'
 

--- a/src/main/java/com/michelet/restaurant/application/command/CheckInCommand.java
+++ b/src/main/java/com/michelet/restaurant/application/command/CheckInCommand.java
@@ -10,6 +10,13 @@ public record CheckInCommand(
         UUID checkedInBy,
         UserRole userRole
 ) {
+    // record canonical constructor 검증
+    public CheckInCommand {
+        restaurantId = validateRestaurantId(restaurantId);
+        reservationId = validateReservationId(reservationId);
+        checkedInBy = validateCheckedInBy(checkedInBy);
+        userRole = validateUserRole(userRole);
+    }
 
     public static CheckInCommand of(
             UUID restaurantId,
@@ -18,10 +25,10 @@ public record CheckInCommand(
             UserRole userRole
     ) {
         return new CheckInCommand(
-                validateRestaurantId(restaurantId),
-                validateReservationId(reservationId),
-                validateCheckedInBy(checkedInBy),
-                validateUserRole(userRole)
+                restaurantId,
+                reservationId,
+                checkedInBy,
+                userRole
         );
     }
 

--- a/src/main/java/com/michelet/restaurant/application/command/CheckInCommand.java
+++ b/src/main/java/com/michelet/restaurant/application/command/CheckInCommand.java
@@ -1,0 +1,44 @@
+package com.michelet.restaurant.application.command;
+
+import java.util.UUID;
+
+public record CheckInCommand(
+        UUID restaurantId,
+        UUID reservationId,
+        UUID checkedInBy
+) {
+
+    public static CheckInCommand of(
+            UUID restaurantId,
+            UUID reservationId,
+            UUID checkedInBy
+    ) {
+        return new CheckInCommand(
+                validateRestaurantId(restaurantId),
+                validateReservationId(reservationId),
+                validateCheckedInBy(checkedInBy)
+        );
+    }
+
+    private static UUID validateRestaurantId(UUID restaurantId) {
+        if (restaurantId == null) {
+            throw new IllegalArgumentException("식당 ID는 필수입니다.");
+        }
+        return restaurantId;
+    }
+
+    private static UUID validateReservationId(UUID reservationId) {
+        if (reservationId == null) {
+            throw new IllegalArgumentException("예약 ID는 필수입니다.");
+        }
+        return reservationId;
+    }
+
+    private static UUID validateCheckedInBy(UUID checkedInBy) {
+        if (checkedInBy == null) {
+            throw new IllegalArgumentException("체크인 처리자 ID는 필수입니다.");
+        }
+        return checkedInBy;
+    }
+
+}

--- a/src/main/java/com/michelet/restaurant/application/command/CheckInCommand.java
+++ b/src/main/java/com/michelet/restaurant/application/command/CheckInCommand.java
@@ -1,22 +1,27 @@
 package com.michelet.restaurant.application.command;
 
+import com.michelet.common.auth.core.enums.UserRole;
+
 import java.util.UUID;
 
 public record CheckInCommand(
         UUID restaurantId,
         UUID reservationId,
-        UUID checkedInBy
+        UUID checkedInBy,
+        UserRole userRole
 ) {
 
     public static CheckInCommand of(
             UUID restaurantId,
             UUID reservationId,
-            UUID checkedInBy
+            UUID checkedInBy,
+            UserRole userRole
     ) {
         return new CheckInCommand(
                 validateRestaurantId(restaurantId),
                 validateReservationId(reservationId),
-                validateCheckedInBy(checkedInBy)
+                validateCheckedInBy(checkedInBy),
+                validateUserRole(userRole)
         );
     }
 
@@ -41,4 +46,10 @@ public record CheckInCommand(
         return checkedInBy;
     }
 
+    private static UserRole validateUserRole(UserRole userRole) {
+        if (userRole == null) {
+            throw new IllegalArgumentException("체크인 처리자 권한은 필수입니다.");
+        }
+        return userRole;
+    }
 }

--- a/src/main/java/com/michelet/restaurant/application/result/CheckInResult.java
+++ b/src/main/java/com/michelet/restaurant/application/result/CheckInResult.java
@@ -1,0 +1,23 @@
+package com.michelet.restaurant.application.result;
+
+import com.michelet.restaurant.domain.model.CheckInStatus;
+import com.michelet.restaurant.domain.model.RestaurantCheckInLog;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record CheckInResult(
+        UUID restaurantId,
+        UUID reservationId,
+        CheckInStatus status,
+        LocalDateTime checkedInAt
+) {
+    public static CheckInResult from(RestaurantCheckInLog checkInLog) {
+        return new CheckInResult(
+                checkInLog.getRestaurantId(),
+                checkInLog.getReservationId(),
+                checkInLog.getStatus(),
+                checkInLog.getCheckedInAt()
+        );
+    }
+}

--- a/src/main/java/com/michelet/restaurant/application/service/command/RestaurantCheckInCommandService.java
+++ b/src/main/java/com/michelet/restaurant/application/service/command/RestaurantCheckInCommandService.java
@@ -1,0 +1,117 @@
+package com.michelet.restaurant.application.service.command;
+
+import com.michelet.common.auth.core.enums.UserRole;
+import com.michelet.common.response.ApiResponse;
+import com.michelet.restaurant.application.command.CheckInCommand;
+import com.michelet.restaurant.application.result.CheckInResult;
+import com.michelet.restaurant.domain.exception.CheckInErrorCode;
+import com.michelet.restaurant.domain.exception.CheckInException;
+import com.michelet.restaurant.domain.exception.RestaurantErrorCode;
+import com.michelet.restaurant.domain.exception.RestaurantException;
+import com.michelet.restaurant.domain.model.Restaurant;
+import com.michelet.restaurant.domain.model.RestaurantCheckInLog;
+import com.michelet.restaurant.domain.repository.RestaurantCheckInLogRepository;
+import com.michelet.restaurant.domain.repository.RestaurantRepository;
+import com.michelet.restaurant.infrastructure.client.ReservationClient;
+import com.michelet.restaurant.infrastructure.client.dto.ReservationCheckInRequest;
+import com.michelet.restaurant.infrastructure.client.dto.ReservationCheckInResponse;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+public class RestaurantCheckInCommandService {
+
+    private final RestaurantRepository restaurantRepository;
+    private final RestaurantCheckInLogRepository restaurantCheckInLogRepository;
+    private final ReservationClient reservationClient;
+
+    public RestaurantCheckInCommandService(RestaurantRepository restaurantRepository, RestaurantCheckInLogRepository restaurantCheckInLogRepository, ReservationClient reservationClient) {
+        this.restaurantRepository = restaurantRepository;
+        this.restaurantCheckInLogRepository = restaurantCheckInLogRepository;
+        this.reservationClient = reservationClient;
+    }
+
+    // 예약 체크인 처리를 수행
+    @Transactional
+    public CheckInResult checkIn(CheckInCommand command) {
+        Restaurant restaurant = getRestaurant(command.restaurantId());
+        validateCheckInAuthority(restaurant, command);
+
+        ReservationCheckInResponse reservationCheckInResponse = requestReservationCheckIn(command);
+        validateReservationCheckInResponse(command, reservationCheckInResponse);
+
+        RestaurantCheckInLog checkInLog = RestaurantCheckInLog.createCheckedIn(
+                command.restaurantId(),
+                command.reservationId(),
+                reservationCheckInResponse.visitDate(),
+                command.checkedInBy(),
+                reservationCheckInResponse.checkedInAt()
+        );
+
+        RestaurantCheckInLog savedCheckInLog = restaurantCheckInLogRepository.save(checkInLog);
+
+        return CheckInResult.from(savedCheckInLog);
+    }
+
+    private Restaurant getRestaurant(UUID restaurantId) {
+        return restaurantRepository.findById(restaurantId)
+                .orElseThrow(() -> new RestaurantException(RestaurantErrorCode.RESTAURANT_404_NOT_FOUND));
+    }
+
+    // 체크인 처리 권한을 검증
+    private void validateCheckInAuthority(Restaurant restaurant, CheckInCommand command) {
+        if (command.userRole() == UserRole.MASTER) {
+            return;
+        }
+
+        if (command.userRole() == UserRole.OWNER
+                && restaurant.getOwnerId().equals(command.checkedInBy())) {
+            return;
+        }
+
+        throw new CheckInException(CheckInErrorCode.CHECKIN_403_FORBIDDEN);
+    }
+
+    private ReservationCheckInResponse requestReservationCheckIn(CheckInCommand command) {
+        ApiResponse<ReservationCheckInResponse> response = reservationClient.checkInReservation(
+                ReservationCheckInRequest.of(
+                        command.reservationId(),
+                        command.restaurantId()
+                ),
+                command.checkedInBy(),
+                command.userRole().name()
+        );
+
+        if (response == null || response.data() == null) {
+            throw new CheckInException(CheckInErrorCode.CHECKIN_502_INVALID_RESERVATION_RESPONSE);
+        }
+
+        return response.data();
+    }
+
+    // reservation-service 체크인 응답을 검증
+    private void validateReservationCheckInResponse(
+            CheckInCommand command,
+            ReservationCheckInResponse response
+    ) {
+        if (response.reservationId() == null
+                || !response.reservationId().equals(command.reservationId())) {
+            throw new CheckInException(CheckInErrorCode.CHECKIN_502_INVALID_RESERVATION_RESPONSE);
+        }
+
+        if (response.restaurantId() == null
+                || !response.restaurantId().equals(command.restaurantId())) {
+            throw new CheckInException(CheckInErrorCode.CHECKIN_502_INVALID_RESERVATION_RESPONSE);
+        }
+
+        if (response.visitDate() == null || response.checkedInAt() == null) {
+            throw new CheckInException(CheckInErrorCode.CHECKIN_502_INVALID_RESERVATION_RESPONSE);
+        }
+
+        if (!response.isCheckedIn()) {
+            throw new CheckInException(CheckInErrorCode.CHECKIN_502_INVALID_RESERVATION_RESPONSE);
+        }
+    }
+}

--- a/src/main/java/com/michelet/restaurant/application/service/command/RestaurantCheckInCommandService.java
+++ b/src/main/java/com/michelet/restaurant/application/service/command/RestaurantCheckInCommandService.java
@@ -97,6 +97,8 @@ public class RestaurantCheckInCommandService {
             throw new CheckInException(CheckInErrorCode.CHECKIN_400_RESERVATION_CHECK_IN_FAILED);
         } catch (FeignException.Conflict exception) {
             throw new CheckInException(CheckInErrorCode.CHECKIN_409_RESERVATION_CHECK_IN_FAILED);
+        } catch (FeignException exception) {
+            throw new CheckInException(CheckInErrorCode.CHECKIN_502_INVALID_RESERVATION_RESPONSE);
         }
     }
 

--- a/src/main/java/com/michelet/restaurant/application/service/command/RestaurantCheckInCommandService.java
+++ b/src/main/java/com/michelet/restaurant/application/service/command/RestaurantCheckInCommandService.java
@@ -15,6 +15,7 @@ import com.michelet.restaurant.domain.repository.RestaurantRepository;
 import com.michelet.restaurant.infrastructure.client.ReservationClient;
 import com.michelet.restaurant.infrastructure.client.dto.ReservationCheckInRequest;
 import com.michelet.restaurant.infrastructure.client.dto.ReservationCheckInResponse;
+import feign.FeignException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -75,20 +76,28 @@ public class RestaurantCheckInCommandService {
     }
 
     private ReservationCheckInResponse requestReservationCheckIn(CheckInCommand command) {
-        ApiResponse<ReservationCheckInResponse> response = reservationClient.checkInReservation(
-                ReservationCheckInRequest.of(
-                        command.reservationId(),
-                        command.restaurantId()
-                ),
-                command.checkedInBy(),
-                command.userRole().name()
-        );
+        try {
+            ApiResponse<ReservationCheckInResponse> response = reservationClient.checkInReservation(
+                    ReservationCheckInRequest.of(
+                            command.reservationId(),
+                            command.restaurantId()
+                    ),
+                    command.checkedInBy(),
+                    command.userRole().name()
+            );
 
-        if (response == null || response.data() == null) {
-            throw new CheckInException(CheckInErrorCode.CHECKIN_502_INVALID_RESERVATION_RESPONSE);
+            if (response == null || response.data() == null) {
+                throw new CheckInException(CheckInErrorCode.CHECKIN_502_INVALID_RESERVATION_RESPONSE);
+            }
+
+            return response.data();
+        } catch (FeignException.NotFound exception) {
+            throw new CheckInException(CheckInErrorCode.CHECKIN_404_RESERVATION_NOT_FOUND);
+        } catch (FeignException.BadRequest exception) {
+            throw new CheckInException(CheckInErrorCode.CHECKIN_400_RESERVATION_CHECK_IN_FAILED);
+        } catch (FeignException.Conflict exception) {
+            throw new CheckInException(CheckInErrorCode.CHECKIN_409_RESERVATION_CHECK_IN_FAILED);
         }
-
-        return response.data();
     }
 
     // reservation-service 체크인 응답을 검증

--- a/src/main/java/com/michelet/restaurant/application/service/command/RestaurantCheckInCommandService.java
+++ b/src/main/java/com/michelet/restaurant/application/service/command/RestaurantCheckInCommandService.java
@@ -40,7 +40,7 @@ public class RestaurantCheckInCommandService {
         validateCheckInAuthority(restaurant, command);
 
         ReservationCheckInResponse reservationCheckInResponse = requestReservationCheckIn(command);
-        validateReservationCheckInResponse(command, reservationCheckInResponse);
+        validateReservationCheckInResponse(reservationCheckInResponse);
 
         RestaurantCheckInLog checkInLog = RestaurantCheckInLog.createCheckedIn(
                 command.restaurantId(),
@@ -92,20 +92,7 @@ public class RestaurantCheckInCommandService {
     }
 
     // reservation-service 체크인 응답을 검증
-    private void validateReservationCheckInResponse(
-            CheckInCommand command,
-            ReservationCheckInResponse response
-    ) {
-        if (response.reservationId() == null
-                || !response.reservationId().equals(command.reservationId())) {
-            throw new CheckInException(CheckInErrorCode.CHECKIN_502_INVALID_RESERVATION_RESPONSE);
-        }
-
-        if (response.restaurantId() == null
-                || !response.restaurantId().equals(command.restaurantId())) {
-            throw new CheckInException(CheckInErrorCode.CHECKIN_502_INVALID_RESERVATION_RESPONSE);
-        }
-
+    private void validateReservationCheckInResponse(ReservationCheckInResponse response) {
         if (response.visitDate() == null || response.checkedInAt() == null) {
             throw new CheckInException(CheckInErrorCode.CHECKIN_502_INVALID_RESERVATION_RESPONSE);
         }

--- a/src/main/java/com/michelet/restaurant/domain/exception/CheckInErrorCode.java
+++ b/src/main/java/com/michelet/restaurant/domain/exception/CheckInErrorCode.java
@@ -9,8 +9,6 @@ public enum CheckInErrorCode implements ErrorCode {
 
     CHECKIN_403_FORBIDDEN("CHECKIN_403_FORBIDDEN", "체크인 처리 권한이 없습니다.", HttpStatus.FORBIDDEN.value()),
 
-    CHECKIN_409_INVALID_STATUS("CHECKIN_409_INVALID_STATUS", "체크인할 수 없는 예약 상태입니다.", HttpStatus.CONFLICT.value()),
-
     CHECKIN_502_INVALID_RESERVATION_RESPONSE("CHECKIN_502_INVALID_RESERVATION_RESPONSE", "예약 서비스 체크인 응답이 올바르지 않습니다.", HttpStatus.BAD_GATEWAY.value());
 
     private final String code;

--- a/src/main/java/com/michelet/restaurant/domain/exception/CheckInErrorCode.java
+++ b/src/main/java/com/michelet/restaurant/domain/exception/CheckInErrorCode.java
@@ -1,0 +1,23 @@
+package com.michelet.restaurant.domain.exception;
+
+import com.michelet.common.exception.ErrorCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum CheckInErrorCode implements ErrorCode {
+
+    CHECKIN_409_INVALID_STATUS("CHECKIN_409_INVALID_STATUS", "체크인할 수 없는 예약 상태입니다.", HttpStatus.CONFLICT.value()),
+
+    CHECKIN_502_INVALID_RESERVATION_RESPONSE("CHECKIN_502_INVALID_RESERVATION_RESPONSE", "예약 서비스 체크인 응답이 올바르지 않습니다.", HttpStatus.BAD_GATEWAY.value());
+
+    private final String code;
+    private final String message;
+    private final int httpStatus;
+
+    CheckInErrorCode(String code, String message, int httpStatus) {
+        this.code = code;
+        this.message = message;
+        this.httpStatus = httpStatus;
+    }
+}

--- a/src/main/java/com/michelet/restaurant/domain/exception/CheckInErrorCode.java
+++ b/src/main/java/com/michelet/restaurant/domain/exception/CheckInErrorCode.java
@@ -7,6 +7,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum CheckInErrorCode implements ErrorCode {
 
+    CHECKIN_403_FORBIDDEN("CHECKIN_403_FORBIDDEN", "체크인 처리 권한이 없습니다.", HttpStatus.FORBIDDEN.value()),
+
     CHECKIN_409_INVALID_STATUS("CHECKIN_409_INVALID_STATUS", "체크인할 수 없는 예약 상태입니다.", HttpStatus.CONFLICT.value()),
 
     CHECKIN_502_INVALID_RESERVATION_RESPONSE("CHECKIN_502_INVALID_RESERVATION_RESPONSE", "예약 서비스 체크인 응답이 올바르지 않습니다.", HttpStatus.BAD_GATEWAY.value());

--- a/src/main/java/com/michelet/restaurant/domain/exception/CheckInErrorCode.java
+++ b/src/main/java/com/michelet/restaurant/domain/exception/CheckInErrorCode.java
@@ -10,7 +10,8 @@ public enum CheckInErrorCode implements ErrorCode {
     CHECKIN_400_RESERVATION_CHECK_IN_FAILED("CHECKIN_400_RESERVATION_CHECK_IN_FAILED", "예약 체크인 처리에 실패했습니다.", HttpStatus.BAD_REQUEST.value()),
     CHECKIN_403_FORBIDDEN("CHECKIN_403_FORBIDDEN", "체크인 처리 권한이 없습니다.", HttpStatus.FORBIDDEN.value()),
     CHECKIN_404_RESERVATION_NOT_FOUND("CHECKIN_404_RESERVATION_NOT_FOUND", "예약을 찾을 수 없습니다.", HttpStatus.NOT_FOUND.value()),
-    CHECKIN_409_RESERVATION_CHECK_IN_FAILED("CHECKIN_409_RESERVATION_CHECK_IN_FAILED", "예약 체크인 처리에 실패했습니다.", HttpStatus.CONFLICT.value()),    CHECKIN_502_INVALID_RESERVATION_RESPONSE("CHECKIN_502_INVALID_RESERVATION_RESPONSE", "예약 서비스 체크인 응답이 올바르지 않습니다.", HttpStatus.BAD_GATEWAY.value());
+    CHECKIN_409_RESERVATION_CHECK_IN_FAILED("CHECKIN_409_RESERVATION_CHECK_IN_FAILED", "예약 체크인 처리에 실패했습니다.", HttpStatus.CONFLICT.value()),
+    CHECKIN_502_INVALID_RESERVATION_RESPONSE("CHECKIN_502_INVALID_RESERVATION_RESPONSE", "예약 서비스 체크인 응답이 올바르지 않습니다.", HttpStatus.BAD_GATEWAY.value());
 
     private final String code;
     private final String message;

--- a/src/main/java/com/michelet/restaurant/domain/exception/CheckInErrorCode.java
+++ b/src/main/java/com/michelet/restaurant/domain/exception/CheckInErrorCode.java
@@ -7,9 +7,10 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum CheckInErrorCode implements ErrorCode {
 
+    CHECKIN_400_RESERVATION_CHECK_IN_FAILED("CHECKIN_400_RESERVATION_CHECK_IN_FAILED", "예약 체크인 처리에 실패했습니다.", HttpStatus.BAD_REQUEST.value()),
     CHECKIN_403_FORBIDDEN("CHECKIN_403_FORBIDDEN", "체크인 처리 권한이 없습니다.", HttpStatus.FORBIDDEN.value()),
-
-    CHECKIN_502_INVALID_RESERVATION_RESPONSE("CHECKIN_502_INVALID_RESERVATION_RESPONSE", "예약 서비스 체크인 응답이 올바르지 않습니다.", HttpStatus.BAD_GATEWAY.value());
+    CHECKIN_404_RESERVATION_NOT_FOUND("CHECKIN_404_RESERVATION_NOT_FOUND", "예약을 찾을 수 없습니다.", HttpStatus.NOT_FOUND.value()),
+    CHECKIN_409_RESERVATION_CHECK_IN_FAILED("CHECKIN_409_RESERVATION_CHECK_IN_FAILED", "예약 체크인 처리에 실패했습니다.", HttpStatus.CONFLICT.value()),    CHECKIN_502_INVALID_RESERVATION_RESPONSE("CHECKIN_502_INVALID_RESERVATION_RESPONSE", "예약 서비스 체크인 응답이 올바르지 않습니다.", HttpStatus.BAD_GATEWAY.value());
 
     private final String code;
     private final String message;

--- a/src/main/java/com/michelet/restaurant/domain/exception/CheckInException.java
+++ b/src/main/java/com/michelet/restaurant/domain/exception/CheckInException.java
@@ -1,0 +1,11 @@
+package com.michelet.restaurant.domain.exception;
+
+import com.michelet.common.exception.BusinessException;
+import com.michelet.common.exception.ErrorCode;
+
+public class CheckInException extends BusinessException {
+
+    public CheckInException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/michelet/restaurant/domain/model/CheckInStatus.java
+++ b/src/main/java/com/michelet/restaurant/domain/model/CheckInStatus.java
@@ -1,0 +1,12 @@
+package com.michelet.restaurant.domain.model;
+
+// 식당 체크인 이력 상태 표현
+public enum CheckInStatus {
+
+    // 체크인 대기
+    PENDING,
+    // 체크인 완료
+    CHECKED_IN,
+    // 방문하지 않은 상태
+    NO_SHOW,
+}

--- a/src/main/java/com/michelet/restaurant/domain/model/RestaurantCheckInLog.java
+++ b/src/main/java/com/michelet/restaurant/domain/model/RestaurantCheckInLog.java
@@ -1,14 +1,22 @@
 package com.michelet.restaurant.domain.model;
 
 import com.michelet.common.entity.BaseEntity;
-import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
+import jakarta.persistence.Access;
+import jakarta.persistence.AccessType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
@@ -17,10 +25,15 @@ import java.util.UUID;
         indexes = {
                 // 식당 기준 체크인 이력 조회 대비
                 @Index(name = "idx_checkin_log_restaurant_id", columnList = "restaurant_id"),
-                // 예약 ID 기준 중복 체크/추적 대비
-                @Index(name = "idx_checkin_log_reservation_id", columnList = "reservation_id"),
                 // 방문 일자 기준 이력 조회 대비
                 @Index(name = "idx_checkin_log_visit_date", columnList = "visit_date")
+        },
+        uniqueConstraints = {
+                // 하나의 예약에 대해 체크인 로그가 중복 저장되지 않도록 방어
+                @UniqueConstraint(
+                        name = "uk_checkin_log_reservation_id",
+                        columnNames = "reservation_id"
+                )
         }
 )
 @Access(AccessType.FIELD)
@@ -28,13 +41,13 @@ import java.util.UUID;
 public class RestaurantCheckInLog extends BaseEntity {
 
     @Id
-    @Column(name = "checkin_log_id", nullable = false, updatable = false)
+    @Column(name = "checkin_log_id", nullable = false, updatable = false, columnDefinition = "uuid")
     private UUID checkinLogId;
 
-    @Column(name = "restaurant_id", nullable = false)
+    @Column(name = "restaurant_id", nullable = false, columnDefinition = "uuid")
     private UUID restaurantId;
 
-    @Column(name = "reservation_id", nullable = false)
+    @Column(name = "reservation_id", nullable = false, columnDefinition = "uuid")
     private UUID reservationId;
 
     @Column(name = "visit_date", nullable = false)
@@ -44,15 +57,16 @@ public class RestaurantCheckInLog extends BaseEntity {
     @Column(name = "status", nullable = false, length = 30)
     private CheckInStatus status;
 
-    @Column(name = "checked_in_by", nullable = false)
+    @Column(name = "checked_in_by", nullable = false, columnDefinition = "uuid")
     private UUID checkedInBy;
 
     @Column(name = "checked_in_at", nullable = false)
     private LocalDateTime checkedInAt;
 
-    @Column(name = "note", columnDefinition = "text")
+    @Column(name = "note", columnDefinition = "TEXT")
     private String note;
 
+    // 식당 체크인 이력을 생성
     private RestaurantCheckInLog(
             UUID restaurantId,
             UUID reservationId,
@@ -72,6 +86,7 @@ public class RestaurantCheckInLog extends BaseEntity {
         this.note = normalizeNote(note);
     }
 
+    // 체크인 완료 이력을 생성
     public static RestaurantCheckInLog createCheckedIn(
             UUID restaurantId,
             UUID reservationId,

--- a/src/main/java/com/michelet/restaurant/domain/model/RestaurantCheckInLog.java
+++ b/src/main/java/com/michelet/restaurant/domain/model/RestaurantCheckInLog.java
@@ -1,0 +1,146 @@
+package com.michelet.restaurant.domain.model;
+
+import com.michelet.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Entity
+@Table(
+        name = "p_restaurant_checkin_log",
+        indexes = {
+                // 식당 기준 체크인 이력 조회 대비
+                @Index(name = "idx_checkin_log_restaurant_id", columnList = "restaurant_id"),
+                // 예약 ID 기준 중복 체크/추적 대비
+                @Index(name = "idx_checkin_log_reservation_id", columnList = "reservation_id"),
+                // 방문 일자 기준 이력 조회 대비
+                @Index(name = "idx_checkin_log_visit_date", columnList = "visit_date")
+        }
+)
+@Access(AccessType.FIELD)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RestaurantCheckInLog extends BaseEntity {
+
+    @Id
+    @Column(name = "checkin_log_id", nullable = false, updatable = false)
+    private UUID checkinLogId;
+
+    @Column(name = "restaurant_id", nullable = false)
+    private UUID restaurantId;
+
+    @Column(name = "reservation_id", nullable = false)
+    private UUID reservationId;
+
+    @Column(name = "visit_date", nullable = false)
+    private LocalDate visitDate;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 30)
+    private CheckInStatus status;
+
+    @Column(name = "checked_in_by", nullable = false)
+    private UUID checkedInBy;
+
+    @Column(name = "checked_in_at", nullable = false)
+    private LocalDateTime checkedInAt;
+
+    @Column(name = "note", columnDefinition = "text")
+    private String note;
+
+    private RestaurantCheckInLog(
+            UUID restaurantId,
+            UUID reservationId,
+            LocalDate visitDate,
+            CheckInStatus status,
+            UUID checkedInBy,
+            LocalDateTime checkedInAt,
+            String note
+    ) {
+        this.checkinLogId = UUID.randomUUID();
+        this.restaurantId = validateRestaurantId(restaurantId);
+        this.reservationId = validateReservationId(reservationId);
+        this.visitDate = validateVisitDate(visitDate);
+        this.status = validateStatus(status);
+        this.checkedInBy = validateCheckedInBy(checkedInBy);
+        this.checkedInAt = validateCheckedInAt(checkedInAt);
+        this.note = normalizeNote(note);
+    }
+
+    public static RestaurantCheckInLog createCheckedIn(
+            UUID restaurantId,
+            UUID reservationId,
+            UUID checkedInBy,
+            LocalDateTime checkedInAt
+    ) {
+        if (checkedInAt == null) {
+            throw new IllegalArgumentException("체크인 처리 시각은 필수입니다.");
+        }
+
+        return new RestaurantCheckInLog(
+                restaurantId,
+                reservationId,
+                checkedInAt.toLocalDate(),
+                CheckInStatus.CHECKED_IN,
+                checkedInBy,
+                checkedInAt,
+                null
+        );
+    }
+
+    private UUID validateRestaurantId(UUID restaurantId) {
+        if (restaurantId == null) {
+            throw new IllegalArgumentException("식당 ID는 필수입니다.");
+        }
+        return restaurantId;
+    }
+
+    private UUID validateReservationId(UUID reservationId) {
+        if (reservationId == null) {
+            throw new IllegalArgumentException("예약 ID는 필수입니다.");
+        }
+        return reservationId;
+    }
+
+    private LocalDate validateVisitDate(LocalDate visitDate) {
+        if (visitDate == null) {
+            throw new IllegalArgumentException("방문 일자는 필수입니다.");
+        }
+        return visitDate;
+    }
+
+    private CheckInStatus validateStatus(CheckInStatus status) {
+        if (status == null) {
+            throw new IllegalArgumentException("체크인 상태는 필수입니다.");
+        }
+        return status;
+    }
+
+    private UUID validateCheckedInBy(UUID checkedInBy) {
+        if (checkedInBy == null) {
+            throw new IllegalArgumentException("체크인 처리자 ID는 필수입니다.");
+        }
+        return checkedInBy;
+    }
+
+    private LocalDateTime validateCheckedInAt(LocalDateTime checkedInAt) {
+        if (checkedInAt == null) {
+            throw new IllegalArgumentException("체크인 처리 시각은 필수입니다.");
+        }
+        return checkedInAt;
+    }
+
+    private String normalizeNote(String note) {
+        if (note == null) {
+            return null;
+        }
+
+        String normalized = note.trim();
+        return normalized.isBlank() ? null : normalized;
+    }
+}

--- a/src/main/java/com/michelet/restaurant/domain/model/RestaurantCheckInLog.java
+++ b/src/main/java/com/michelet/restaurant/domain/model/RestaurantCheckInLog.java
@@ -75,17 +75,14 @@ public class RestaurantCheckInLog extends BaseEntity {
     public static RestaurantCheckInLog createCheckedIn(
             UUID restaurantId,
             UUID reservationId,
+            LocalDate visitDate,
             UUID checkedInBy,
             LocalDateTime checkedInAt
     ) {
-        if (checkedInAt == null) {
-            throw new IllegalArgumentException("체크인 처리 시각은 필수입니다.");
-        }
-
         return new RestaurantCheckInLog(
                 restaurantId,
                 reservationId,
-                checkedInAt.toLocalDate(),
+                visitDate,
                 CheckInStatus.CHECKED_IN,
                 checkedInBy,
                 checkedInAt,

--- a/src/main/java/com/michelet/restaurant/domain/repository/RestaurantCheckInLogRepository.java
+++ b/src/main/java/com/michelet/restaurant/domain/repository/RestaurantCheckInLogRepository.java
@@ -1,0 +1,9 @@
+package com.michelet.restaurant.domain.repository;
+
+import com.michelet.restaurant.domain.model.RestaurantCheckInLog;
+
+public interface RestaurantCheckInLogRepository {
+
+    // 체크인 이력 저장
+    RestaurantCheckInLog save(RestaurantCheckInLog restaurantCheckInLog);
+}

--- a/src/main/java/com/michelet/restaurant/infrastructure/client/ReservationClient.java
+++ b/src/main/java/com/michelet/restaurant/infrastructure/client/ReservationClient.java
@@ -1,0 +1,20 @@
+package com.michelet.restaurant.infrastructure.client;
+
+import com.michelet.common.response.ApiResponse;
+import com.michelet.restaurant.infrastructure.client.dto.ReservationCheckInRequest;
+import com.michelet.restaurant.infrastructure.client.dto.ReservationCheckInResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+import java.util.UUID;
+
+@FeignClient(name = "reservation-service")
+public interface ReservationClient {
+
+    @PatchMapping("/internal/reservations/check-in")
+    ApiResponse<ReservationCheckInResponse> checkInReservation(@RequestBody ReservationCheckInRequest request,
+                                                               @RequestHeader("X-User-Id") UUID userId,
+                                                               @RequestHeader("X-User-Role") String userRole);
+}

--- a/src/main/java/com/michelet/restaurant/infrastructure/client/ReservationClient.java
+++ b/src/main/java/com/michelet/restaurant/infrastructure/client/ReservationClient.java
@@ -10,7 +10,10 @@ import org.springframework.web.bind.annotation.RequestHeader;
 
 import java.util.UUID;
 
-@FeignClient(name = "reservation-service")
+@FeignClient(
+        name = "reservation-service",
+        url = "${feign.reservation-service.url:}"
+)
 public interface ReservationClient {
 
     @PatchMapping("/internal/reservations/check-in")

--- a/src/main/java/com/michelet/restaurant/infrastructure/client/dto/ReservationCheckInRequest.java
+++ b/src/main/java/com/michelet/restaurant/infrastructure/client/dto/ReservationCheckInRequest.java
@@ -1,0 +1,34 @@
+package com.michelet.restaurant.infrastructure.client.dto;
+
+import java.util.UUID;
+
+// reservation-service 내부 체크인 API 요청 DTO
+public record ReservationCheckInRequest(
+        UUID reservationId,
+        UUID restaurantId
+) {
+    public static ReservationCheckInRequest of(
+            UUID reservationId,
+            UUID restaurantId
+    ) {
+        return new ReservationCheckInRequest(
+                validateReservationId(reservationId),
+                validateRestaurantId(restaurantId)
+        );
+    }
+
+    private static UUID validateReservationId(UUID reservationId) {
+        if (reservationId == null) {
+            throw new IllegalArgumentException("예약 ID는 필수입니다.");
+        }
+        return reservationId;
+    }
+
+    private static UUID validateRestaurantId(UUID restaurantId) {
+        if (restaurantId == null) {
+            throw new IllegalArgumentException("식당 ID는 필수입니다.");
+        }
+        return restaurantId;
+    }
+
+}

--- a/src/main/java/com/michelet/restaurant/infrastructure/client/dto/ReservationCheckInResponse.java
+++ b/src/main/java/com/michelet/restaurant/infrastructure/client/dto/ReservationCheckInResponse.java
@@ -10,7 +10,7 @@ public record ReservationCheckInResponse(
     private static final String CHECKED_IN_STATUS = "CHECKED_IN";
 
     // reservation-service 응답 상태가 체크인 완료 상태인지 확인
-    public boolean inCheckedIn() {
+    public boolean isCheckedIn() {
         return CHECKED_IN_STATUS.equals(status);
     }
 }

--- a/src/main/java/com/michelet/restaurant/infrastructure/client/dto/ReservationCheckInResponse.java
+++ b/src/main/java/com/michelet/restaurant/infrastructure/client/dto/ReservationCheckInResponse.java
@@ -17,6 +17,6 @@ public record ReservationCheckInResponse(
 
     // reservation-service 응답 상태가 체크인 완료 상태인지 확인
     public boolean isCheckedIn() {
-        return COMPLETED_STATUS .equals(status);
+        return COMPLETED_STATUS.equals(status);
     }
 }

--- a/src/main/java/com/michelet/restaurant/infrastructure/client/dto/ReservationCheckInResponse.java
+++ b/src/main/java/com/michelet/restaurant/infrastructure/client/dto/ReservationCheckInResponse.java
@@ -1,12 +1,18 @@
 package com.michelet.restaurant.infrastructure.client.dto;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 // reservation-service 내부 체크인 API 응답 DTO
 public record ReservationCheckInResponse(
         UUID reservationId,
-        String status
+        UUID restaurantId,
+        LocalDate visitDate,
+        String status,
+        LocalDateTime checkedInAt
 ) {
+
     private static final String CHECKED_IN_STATUS = "CHECKED_IN";
 
     // reservation-service 응답 상태가 체크인 완료 상태인지 확인

--- a/src/main/java/com/michelet/restaurant/infrastructure/client/dto/ReservationCheckInResponse.java
+++ b/src/main/java/com/michelet/restaurant/infrastructure/client/dto/ReservationCheckInResponse.java
@@ -13,10 +13,10 @@ public record ReservationCheckInResponse(
         LocalDateTime checkedInAt
 ) {
 
-    private static final String CHECKED_IN_STATUS = "CHECKED_IN";
+    private static final String COMPLETED_STATUS  = "COMPLETED";
 
     // reservation-service 응답 상태가 체크인 완료 상태인지 확인
     public boolean isCheckedIn() {
-        return CHECKED_IN_STATUS.equals(status);
+        return COMPLETED_STATUS .equals(status);
     }
 }

--- a/src/main/java/com/michelet/restaurant/infrastructure/client/dto/ReservationCheckInResponse.java
+++ b/src/main/java/com/michelet/restaurant/infrastructure/client/dto/ReservationCheckInResponse.java
@@ -1,0 +1,16 @@
+package com.michelet.restaurant.infrastructure.client.dto;
+
+import java.util.UUID;
+
+// reservation-service 내부 체크인 API 응답 DTO
+public record ReservationCheckInResponse(
+        UUID reservationId,
+        String status
+) {
+    private static final String CHECKED_IN_STATUS = "CHECKED_IN";
+
+    // reservation-service 응답 상태가 체크인 완료 상태인지 확인
+    public boolean inCheckedIn() {
+        return CHECKED_IN_STATUS.equals(status);
+    }
+}

--- a/src/main/java/com/michelet/restaurant/infrastructure/persistence/RestaurantCheckInLogJpaRepository.java
+++ b/src/main/java/com/michelet/restaurant/infrastructure/persistence/RestaurantCheckInLogJpaRepository.java
@@ -1,0 +1,11 @@
+package com.michelet.restaurant.infrastructure.persistence;
+
+import com.michelet.restaurant.domain.model.RestaurantCheckInLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface RestaurantCheckInLogJpaRepository extends JpaRepository<RestaurantCheckInLog, UUID> {
+
+    // 저장만 필요(JpaRepository가 이미 제공) 추후 추가
+}

--- a/src/main/java/com/michelet/restaurant/infrastructure/persistence/RestaurantCheckInLogRepositoryImpl.java
+++ b/src/main/java/com/michelet/restaurant/infrastructure/persistence/RestaurantCheckInLogRepositoryImpl.java
@@ -1,0 +1,21 @@
+package com.michelet.restaurant.infrastructure.persistence;
+
+import com.michelet.restaurant.domain.model.RestaurantCheckInLog;
+import com.michelet.restaurant.domain.repository.RestaurantCheckInLogRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class RestaurantCheckInLogRepositoryImpl implements RestaurantCheckInLogRepository {
+
+    private final RestaurantCheckInLogJpaRepository restaurantCheckInLogJpaRepository;
+
+    public RestaurantCheckInLogRepositoryImpl(RestaurantCheckInLogJpaRepository restaurantCheckInLogJpaRepository) {
+        this.restaurantCheckInLogJpaRepository = restaurantCheckInLogJpaRepository;
+    }
+
+    // 체크인 이력 저장
+    @Override
+    public RestaurantCheckInLog save(RestaurantCheckInLog restaurantCheckInLog) {
+        return restaurantCheckInLogJpaRepository.save(restaurantCheckInLog);
+    }
+}

--- a/src/main/java/com/michelet/restaurant/presentation/controller/external/RestaurantCheckInController.java
+++ b/src/main/java/com/michelet/restaurant/presentation/controller/external/RestaurantCheckInController.java
@@ -32,7 +32,7 @@ public class RestaurantCheckInController {
     @PatchMapping("/{restaurantId}/reservations/{reservationId}/check-in")
     public ApiResponse<CheckInResponse> checkIn(@PathVariable UUID restaurantId, @PathVariable UUID reservationId) {
 
-        UserContext userContext = UserContextHolder.get();
+        UserContext userContext = getAuthenticatedUserContext();
 
         CheckInCommand command = CheckInCommand.of(
                 restaurantId,
@@ -44,6 +44,16 @@ public class RestaurantCheckInController {
         CheckInResult result = restaurantCheckInCommandService.checkIn(command);
 
         return ApiResponse.ok(CheckInResponse.from(result));
+    }
+
+    private UserContext getAuthenticatedUserContext() {
+        UserContext userContext = UserContextHolder.get();
+
+        if (userContext == null) {
+            throw new RestaurantException(RestaurantErrorCode.RESTAURANT_401_INVALID_AUTH_USER_ID);
+        }
+
+        return userContext;
     }
 
     private UUID parseAuthenticatedUserId(String userId) {

--- a/src/main/java/com/michelet/restaurant/presentation/controller/external/RestaurantCheckInController.java
+++ b/src/main/java/com/michelet/restaurant/presentation/controller/external/RestaurantCheckInController.java
@@ -1,0 +1,60 @@
+package com.michelet.restaurant.presentation.controller.external;
+
+import com.michelet.common.auth.core.annotation.RequireRole;
+import com.michelet.common.auth.core.context.UserContext;
+import com.michelet.common.auth.core.enums.UserRole;
+import com.michelet.common.auth.webmvc.context.UserContextHolder;
+import com.michelet.common.response.ApiResponse;
+import com.michelet.restaurant.application.command.CheckInCommand;
+import com.michelet.restaurant.application.result.CheckInResult;
+import com.michelet.restaurant.application.service.command.RestaurantCheckInCommandService;
+import com.michelet.restaurant.domain.exception.RestaurantErrorCode;
+import com.michelet.restaurant.domain.exception.RestaurantException;
+import com.michelet.restaurant.presentation.dto.CheckInResponse;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/restaurants")
+public class RestaurantCheckInController {
+
+    private final RestaurantCheckInCommandService restaurantCheckInCommandService;
+
+    public RestaurantCheckInController(RestaurantCheckInCommandService restaurantCheckInCommandService) {
+        this.restaurantCheckInCommandService = restaurantCheckInCommandService;
+    }
+
+    @RequireRole({UserRole.OWNER, UserRole.MASTER})
+    @PatchMapping("/{restaurantId}/reservations/{reservationId}/check-in")
+    public ApiResponse<CheckInResponse> checkIn(@PathVariable UUID restaurantId, @PathVariable UUID reservationId) {
+
+        UserContext userContext = UserContextHolder.get();
+
+        CheckInCommand command = CheckInCommand.of(
+                restaurantId,
+                reservationId,
+                parseAuthenticatedUserId(userContext.userId()),
+                userContext.role()
+        );
+
+        CheckInResult result = restaurantCheckInCommandService.checkIn(command);
+
+        return ApiResponse.ok(CheckInResponse.from(result));
+    }
+
+    private UUID parseAuthenticatedUserId(String userId) {
+        if (userId == null || userId.isBlank()) {
+            throw new RestaurantException(RestaurantErrorCode.RESTAURANT_401_INVALID_AUTH_USER_ID);
+        }
+
+        try {
+            return UUID.fromString(userId);
+        } catch (IllegalArgumentException exception) {
+            throw new RestaurantException(RestaurantErrorCode.RESTAURANT_401_INVALID_AUTH_USER_ID);
+        }
+    }
+}

--- a/src/main/java/com/michelet/restaurant/presentation/dto/CheckInResponse.java
+++ b/src/main/java/com/michelet/restaurant/presentation/dto/CheckInResponse.java
@@ -1,0 +1,24 @@
+package com.michelet.restaurant.presentation.dto;
+
+import com.michelet.restaurant.application.result.CheckInResult;
+import com.michelet.restaurant.domain.model.CheckInStatus;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record CheckInResponse(
+        UUID restaurantId,
+        UUID reservationId,
+        CheckInStatus checkInStatus,
+        LocalDateTime checkedInAt
+) {
+    public static CheckInResponse from(CheckInResult result) {
+        return new CheckInResponse(
+                result.restaurantId(),
+                result.reservationId(),
+                result.status(),
+                result.checkedInAt()
+        );
+    }
+
+}

--- a/src/main/java/com/michelet/restaurant/presentation/exception/RestaurantWebExceptionHandler.java
+++ b/src/main/java/com/michelet/restaurant/presentation/exception/RestaurantWebExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.michelet.restaurant.presentation.exception;
 
 import com.michelet.common.response.ApiResponse;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -10,12 +11,26 @@ import org.springframework.web.server.ResponseStatusException;
 public class RestaurantWebExceptionHandler {
 
     @ExceptionHandler(ResponseStatusException.class)
-    public ResponseEntity<ApiResponse<Void>> handleResponseStatusException(ResponseStatusException exception) {
+    public ResponseEntity<ApiResponse<Void>> handleResponseStatusException(
+            ResponseStatusException exception
+    ) {
+        HttpStatusCode statusCode = exception.getStatusCode();
+
         return ResponseEntity
-                .status(exception.getStatusCode())
+                .status(statusCode)
                 .body(ApiResponse.fail(
-                        "AUTH_" + exception.getStatusCode().value(),
+                        resolveErrorCode(statusCode),
                         exception.getReason()
                 ));
+    }
+
+    private String resolveErrorCode(HttpStatusCode statusCode) {
+        int status = statusCode.value();
+
+        if (status == 401 || status == 403) {
+            return "AUTH_" + status;
+        }
+
+        return "WEB_" + status;
     }
 }

--- a/src/main/java/com/michelet/restaurant/presentation/exception/RestaurantWebExceptionHandler.java
+++ b/src/main/java/com/michelet/restaurant/presentation/exception/RestaurantWebExceptionHandler.java
@@ -1,0 +1,21 @@
+package com.michelet.restaurant.presentation.exception;
+
+import com.michelet.common.response.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.server.ResponseStatusException;
+
+@RestControllerAdvice
+public class RestaurantWebExceptionHandler {
+
+    @ExceptionHandler(ResponseStatusException.class)
+    public ResponseEntity<ApiResponse<Void>> handleResponseStatusException(ResponseStatusException exception) {
+        return ResponseEntity
+                .status(exception.getStatusCode())
+                .body(ApiResponse.fail(
+                        "AUTH_" + exception.getStatusCode().value(),
+                        exception.getReason()
+                ));
+    }
+}

--- a/src/test/http/check-in-api.http
+++ b/src/test/http/check-in-api.http
@@ -249,30 +249,51 @@ Authorization: Bearer {{userToken}}
 
 
 ### 7. 같은 예약 재체크인 - 중복 체크인 실패 확인
+### 기대: 400 Bad Request
 PATCH {{gatewayUrl}}/api/v1/restaurants/{{restaurantId}}/reservations/{{reservationId}}/check-in
 Authorization: Bearer {{ownerToken}}
 
 > {%
-    client.log("중복 체크인 응답");
-    client.log(JSON.stringify(response.body, null, 2));
+    if (response.status !== 400) {
+        client.log(JSON.stringify(response.body, null, 2));
+        throw new Error("중복 체크인 실패 응답이 400이 아닙니다.");
+    }
+
+    if (response.body.success !== false) {
+        client.log(JSON.stringify(response.body, null, 2));
+        throw new Error("중복 체크인 응답 success 값이 false가 아닙니다.");
+    }
 %}
 
-
 ### 8. USER 토큰으로 체크인 시도 - 권한 실패 확인
+### 기대: 403 Forbidden
 PATCH {{gatewayUrl}}/api/v1/restaurants/{{restaurantId}}/reservations/{{reservationId}}/check-in
 Authorization: Bearer {{userToken}}
 
 > {%
-    client.log("USER 체크인 시도 응답");
-    client.log(JSON.stringify(response.body, null, 2));
-%}
+    if (response.status !== 403) {
+        client.log(JSON.stringify(response.body, null, 2));
+        throw new Error("USER 체크인 권한 실패 응답이 403이 아닙니다.");
+    }
 
+    if (response.body.success !== false) {
+        client.log(JSON.stringify(response.body, null, 2));
+        throw new Error("USER 체크인 권한 실패 응답 success 값이 false가 아닙니다.");
+    }
+%}
 
 ### 9. 존재하지 않는 식당 체크인 - 404 확인
 PATCH {{gatewayUrl}}/api/v1/restaurants/00000000-0000-0000-0000-000000000000/reservations/{{reservationId}}/check-in
 Authorization: Bearer {{ownerToken}}
 
 > {%
-    client.log("존재하지 않는 식당 체크인 응답");
-    client.log(JSON.stringify(response.body, null, 2));
+    if (response.status !== 404) {
+        client.log(JSON.stringify(response.body, null, 2));
+        throw new Error("존재하지 않는 식당 체크인 응답이 404가 아닙니다.");
+    }
+
+    if (response.body.success !== false) {
+        client.log(JSON.stringify(response.body, null, 2));
+        throw new Error("존재하지 않는 식당 체크인 응답 success 값이 false가 아닙니다.");
+    }
 %}

--- a/src/test/http/check-in-api.http
+++ b/src/test/http/check-in-api.http
@@ -1,0 +1,278 @@
+### 공통 변수
+### Gateway 경유 호출
+@gatewayUrl = http://localhost:19000
+
+### 직접 reservation-service 호출이 필요할 때만 사용
+@reservationDirectUrl = http://localhost:19500
+
+### 테스트 OWNER 계정
+@ownerLoginId = test9
+@ownerPassword = test123!
+
+### 테스트 USER 계정
+@userLoginId = test8
+@userPassword = test123!
+
+### 예약 생성용 임시 값
+### RESERVATION_006이 나오면 reservedDate/slotStartTime 또는 timeSlotId를 바꿔서 다시 실행
+# @timeSlotId = 66666666-6666-6666-6666-666666666666
+
+### 예약일은 반드시 오늘 이후 날짜로 맞춰서 사용
+@reservedDate = 2026-06-01
+@slotStartTime = 18:00:00
+
+
+### 0-1. OWNER 로그인
+POST {{gatewayUrl}}/api/v1/auth/login
+Content-Type: application/json
+
+{
+  "loginId": "{{ownerLoginId}}",
+  "password": "{{ownerPassword}}"
+}
+
+> {%
+    client.global.clear("ownerToken");
+    client.global.clear("ownerId");
+
+    let token = null;
+
+    if (response.body.data && response.body.data.accessToken) {
+        token = response.body.data.accessToken;
+    } else if (response.body.accessToken) {
+        token = response.body.accessToken;
+    }
+
+    if (!token) {
+        throw new Error("OWNER accessToken을 찾지 못했습니다.");
+    }
+
+    client.global.set("ownerToken", token);
+    client.log("ownerToken saved length = " + token.length);
+
+    let payloadBase64 = token.split(".")[1].replace(/-/g, "+").replace(/_/g, "/");
+    payloadBase64 += "=".repeat((4 - payloadBase64.length % 4) % 4);
+
+    const payload = JSON.parse(atob(payloadBase64));
+
+    client.global.set("ownerId", payload["sub"]);
+    client.log("ownerId saved = " + payload["sub"]);
+    client.log("owner role = " + payload["role"]);
+%}
+
+
+### 0-2. USER 로그인
+POST {{gatewayUrl}}/api/v1/auth/login
+Content-Type: application/json
+
+{
+  "loginId": "{{userLoginId}}",
+  "password": "{{userPassword}}"
+}
+
+> {%
+    client.global.clear("userToken");
+    client.global.clear("userId");
+
+    let token = null;
+
+    if (response.body.data && response.body.data.accessToken) {
+        token = response.body.data.accessToken;
+    } else if (response.body.accessToken) {
+        token = response.body.accessToken;
+    }
+
+    if (!token) {
+        throw new Error("USER accessToken을 찾지 못했습니다.");
+    }
+
+    client.global.set("userToken", token);
+
+    let payloadBase64 = token.split(".")[1].replace(/-/g, "+").replace(/_/g, "/");
+    payloadBase64 += "=".repeat((4 - payloadBase64.length % 4) % 4);
+
+    const payload = JSON.parse(atob(payloadBase64));
+
+    client.global.set("userId", payload.sub);
+    client.log("userId saved = " + payload.sub);
+%}
+
+
+### 식당 등록
+POST {{gatewayUrl}}/api/v1/restaurants
+Content-Type: application/json
+Authorization: Bearer {{ownerToken}}
+
+{
+  "name": "MicheLet CheckIn Test",
+  "address": "서울특별시 강남구 테헤란로 123",
+  "phone": "02-1234-5678",
+  "description": "체크인 테스트용 레스토랑",
+  "reservationOpenAt": "10:00:00",
+  "avgMealDurationMin": 90,
+  "status": "OPEN",
+  "businessHours": "MON-FRI 11:00-20:00 / SAT,SUN CLOSED"
+}
+
+> {%
+    client.global.clear("restaurantId");
+
+    if (response.status === 200 && response.body.data) {
+        client.global.set("restaurantId", response.body.data.restaurantId);
+        client.log("restaurantId saved = " + response.body.data.restaurantId);
+    } else {
+        client.log(JSON.stringify(response.body, null, 2));
+        throw new Error("식당 등록 실패");
+    }
+%}
+
+
+### 2. 코스 등록
+### OWNER 토큰으로 Gateway 경유
+POST {{gatewayUrl}}/api/v1/restaurants/{{restaurantId}}/courses
+Content-Type: application/json
+Authorization: Bearer {{ownerToken}}
+
+{
+  "name": "Dinner Course",
+  "price": 150000,
+  "sessionType": "DINNER",
+  "status": "AVAILABLE",
+  "menus": [
+    {
+      "coursePart": "AMUSE_BOUCHE",
+      "menuName": "한우 타르타르",
+      "sortOrder": 1
+    },
+    {
+      "coursePart": "APPETIZER",
+      "menuName": "제철 샐러드",
+      "sortOrder": 2
+    },
+    {
+      "coursePart": "FISH",
+      "menuName": "제철 생선 구이",
+      "sortOrder": 3
+    },
+    {
+      "coursePart": "MAIN",
+      "menuName": "양갈비",
+      "sortOrder": 4
+    },
+    {
+      "coursePart": "DESSERT",
+      "menuName": "바닐라 무스",
+      "sortOrder": 5
+    }
+  ]
+}
+
+> {%
+    client.global.clear("courseId");
+
+    if (response.status === 200 && response.body.data) {
+        client.global.set("courseId", response.body.data.courseId);
+        client.log("courseId saved = " + response.body.data.courseId);
+    } else {
+        client.log(JSON.stringify(response.body, null, 2));
+        throw new Error("코스 등록 실패");
+    }
+%}
+
+
+### 3. 예약 생성
+### USER 권한 필요
+### 외부 API이므로 Gateway 경유
+### reservation-service 기준 X-Waiting-Token 형식: userId:restaurantId
+### timeSlotId는 중복 예약 방지를 위해 매 요청마다 동적 UUID 사용
+POST {{gatewayUrl}}/api/v1/reservations
+Content-Type: application/json
+Authorization: Bearer {{userToken}}
+X-Waiting-Token: {{userId}}:{{restaurantId}}
+
+{
+  "restaurantId": "{{restaurantId}}",
+  "timeSlotId": "{{$uuid}}",
+  "reservedDate": "{{reservedDate}}",
+  "slotStartTime": "{{slotStartTime}}",
+  "guestCount": 2,
+  "courses": [
+    {
+      "courseId": "{{courseId}}",
+      "quantity": 1,
+      "unitPrice": 150000
+    }
+  ]
+}
+
+> {%
+    client.global.clear("reservationId");
+
+    if ((response.status === 200 || response.status === 201) && response.body.data) {
+        client.global.set("reservationId", response.body.data.reservationId);
+        client.log("reservationId saved = " + response.body.data.reservationId);
+    } else {
+        client.log(JSON.stringify(response.body, null, 2));
+        throw new Error("예약 생성 실패");
+    }
+%}
+
+
+### 4. 예약 상세 조회 - 체크인 전 상태 확인
+GET {{gatewayUrl}}/api/v1/reservations/{{reservationId}}
+Authorization: Bearer {{userToken}}
+
+
+### 5. 체크인 처리
+### OWNER 토큰으로 Gateway 경유
+### 외부 API이므로 Gateway 경유
+PATCH {{gatewayUrl}}/api/v1/restaurants/{{restaurantId}}/reservations/{{reservationId}}/check-in
+Authorization: Bearer {{ownerToken}}
+
+> {%
+    client.log("체크인 처리 응답");
+    client.log(JSON.stringify(response.body, null, 2));
+
+    if (response.status !== 200) {
+        throw new Error("체크인 처리 실패");
+    }
+
+    if (!response.body.success) {
+        throw new Error("체크인 처리 success=false");
+    }
+%}
+
+
+### 6. 체크인 후 예약 상세 조회 - status COMPLETED 확인
+GET {{gatewayUrl}}/api/v1/reservations/{{reservationId}}
+Authorization: Bearer {{userToken}}
+
+
+### 7. 같은 예약 재체크인 - 중복 체크인 실패 확인
+PATCH {{gatewayUrl}}/api/v1/restaurants/{{restaurantId}}/reservations/{{reservationId}}/check-in
+Authorization: Bearer {{ownerToken}}
+
+> {%
+    client.log("중복 체크인 응답");
+    client.log(JSON.stringify(response.body, null, 2));
+%}
+
+
+### 8. USER 토큰으로 체크인 시도 - 권한 실패 확인
+PATCH {{gatewayUrl}}/api/v1/restaurants/{{restaurantId}}/reservations/{{reservationId}}/check-in
+Authorization: Bearer {{userToken}}
+
+> {%
+    client.log("USER 체크인 시도 응답");
+    client.log(JSON.stringify(response.body, null, 2));
+%}
+
+
+### 9. 존재하지 않는 식당 체크인 - 404 확인
+PATCH {{gatewayUrl}}/api/v1/restaurants/00000000-0000-0000-0000-000000000000/reservations/{{reservationId}}/check-in
+Authorization: Bearer {{ownerToken}}
+
+> {%
+    client.log("존재하지 않는 식당 체크인 응답");
+    client.log(JSON.stringify(response.body, null, 2));
+%}

--- a/src/test/http/restaurant-course-api.http
+++ b/src/test/http/restaurant-course-api.http
@@ -7,12 +7,10 @@
 @restaurantExternalUrl = http://localhost:19000
 
 ### 내부 API는 restaurant-service 직접 호출
-### 내부 API는 @RequireRole 적용 대상 아님
 @restaurantInternalUrl = http://localhost:19300
 
 
 ### 테스트 OWNER 계정
-### 중복 에러가 나면 001 숫자만 바꿔서 다시 실행
 @ownerLoginId = test9
 @ownerPassword = test123!
 @ownerName = owner9
@@ -21,7 +19,6 @@
 
 
 ### 테스트 USER 계정
-### 중복 에러가 나면 001 숫자만 바꿔서 다시 실행
 @userLoginId = test8
 @userPassword = test123!
 @userName = user8


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.

- 식당 체크인 처리 API를 구현
- `PATCH /api/v1/restaurants/{restaurantId}/reservations/{reservationId}/check-in`
- restaurant-service에서 식당 존재 여부와 체크인 처리 권한을 검증
- reservation-service 내부 체크인 API를 동기 호출하여 예약 상태 변경을 위임
- reservation-service 체크인 성공 응답을 기반으로 `p_restaurant_checkin_log`에 체크인 이력을 저장
- 체크인 성공/실패 케이스에 대한 HTTP Client 테스트 시나리오를 추가

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #23 
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to # 

## ✅ 자체 체크리스트 (필수)
- [ ] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [x] IntelliJ HTTP Client 테스트 완료 (인증샷 첨부)
- [x] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [x] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 IntelliJ HTTP Client 실행 화면을 여기에 첨부해 주세요.

<img width="1410" height="683" alt="스크린샷 2026-05-04 144949" src="https://github.com/user-attachments/assets/e84a1b3b-3c4d-4e29-9088-8de6f71645ef" />
<img width="1113" height="681" alt="스크린샷 2026-05-04 144956" src="https://github.com/user-attachments/assets/108361de-f62b-43b7-9798-d49b2be1499d" />
<img width="1075" height="357" alt="스크린샷 2026-05-04 145004" src="https://github.com/user-attachments/assets/6c8b543a-abdc-48b1-ae99-042c77d4750d" />
<img width="1207" height="691" alt="스크린샷 2026-05-04 145014" src="https://github.com/user-attachments/assets/45e7c321-1462-47ae-8b09-a339c4ea2fbd" />
<img width="1588" height="386" alt="스크린샷 2026-05-04 145028" src="https://github.com/user-attachments/assets/5d8f5d72-9363-455d-beda-47c296caae3a" />
<img width="1578" height="370" alt="스크린샷 2026-05-04 145039" src="https://github.com/user-attachments/assets/841ec9d0-f425-46e5-af05-f22a221ef58d" />
<img width="1603" height="387" alt="스크린샷 2026-05-04 145046" src="https://github.com/user-attachments/assets/78827b89-fe12-4ac4-83c2-ece017facc80" />


## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.
> - [ ] 논의점

- reservation-service 내부 체크인 API는 체크인 성공 시 `COMPLETED` 상태를 반환
- restaurant-service에서는 해당 응답을 기반으로 `CHECKED_IN` 로그를 저장
- 체크인 로그의 `visitDate`, `checkedInAt`은 restaurant-service에서 생성하지 않고 reservation-service 응답값을 사용
- reservation-service의 실패 응답은 FeignException으로 수신되므로, restaurant-service에서 체크인 도메인 예외로 변환
- `RestaurantWebExceptionHandler`는 common-auth의 `ResponseStatusException`이 500으로 처리되는 문제를 방지하기 위해 추가
- 
<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 새로운 기능
* 식당 예약 체크인 기능 추가 — OWNER/MASTER 권한으로 체크인 수행 가능
* 체크인 상태(PENDING/CHECKED_IN/NO_SHOW) 기반 이력 생성 및 저장
* 외부 예약 서비스와의 체크인 연동 및 응답 검증

## 테스트
* 체크인 관련 엔드투엔드 HTTP 테스트 시나리오 추가 (성공/중복/권한/미존재 케이스)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->