### PR TITLE
[FEAT] 점주 소유 식당 식별 내부 API 추가

### DIFF
--- a/src/main/java/com/michelet/restaurantservice/restaurant/application/service/RestaurantQueryService.java
+++ b/src/main/java/com/michelet/restaurantservice/restaurant/application/service/RestaurantQueryService.java
@@ -52,6 +52,14 @@ public class RestaurantQueryService {
         return GetRestaurantResult.of(restaurant, courses);
     }
 
+    @Transactional(readOnly = true)
+    public UUID getRestaurantIdByOwnerId(UUID ownerId) {
+        Restaurant restaurant = restaurantRepository.findFirstByOwnerIdAndDeletedAtIsNull(ownerId)
+                .orElseThrow(() -> new RestaurantException(RestaurantErrorCode.RESTAURANT_404_NOT_FOUND));
+
+        return restaurant.getRestaurantId();
+    }
+
     /**
      * 식당 목록/검색 결과를 페이지 단위로 조회
      *

--- a/src/main/java/com/michelet/restaurantservice/restaurant/application/service/RestaurantQueryService.java
+++ b/src/main/java/com/michelet/restaurantservice/restaurant/application/service/RestaurantQueryService.java
@@ -54,7 +54,7 @@ public class RestaurantQueryService {
 
     @Transactional(readOnly = true)
     public UUID getRestaurantIdByOwnerId(UUID ownerId) {
-        Restaurant restaurant = restaurantRepository.findFirstByOwnerIdAndDeletedAtIsNull(ownerId)
+        Restaurant restaurant = restaurantRepository.findByOwnerIdAndDeletedAtIsNull(ownerId)
                 .orElseThrow(() -> new RestaurantException(RestaurantErrorCode.RESTAURANT_404_NOT_FOUND));
 
         return restaurant.getRestaurantId();

--- a/src/main/java/com/michelet/restaurantservice/restaurant/domain/repository/RestaurantRepository.java
+++ b/src/main/java/com/michelet/restaurantservice/restaurant/domain/repository/RestaurantRepository.java
@@ -13,5 +13,5 @@ public interface RestaurantRepository {
 
     List<Restaurant> findAllByOwnerId(UUID ownerId);
 
-    Optional<Restaurant> findFirstByOwnerIdAndDeletedAtIsNull(UUID ownerId);
+    Optional<Restaurant> findByOwnerIdAndDeletedAtIsNull(UUID ownerId);
 }

--- a/src/main/java/com/michelet/restaurantservice/restaurant/domain/repository/RestaurantRepository.java
+++ b/src/main/java/com/michelet/restaurantservice/restaurant/domain/repository/RestaurantRepository.java
@@ -12,4 +12,6 @@ public interface RestaurantRepository {
     Optional<Restaurant> findById(UUID restaurantId);
 
     List<Restaurant> findAllByOwnerId(UUID ownerId);
+
+    Optional<Restaurant> findFirstByOwnerIdAndDeletedAtIsNull(UUID ownerId);
 }

--- a/src/main/java/com/michelet/restaurantservice/restaurant/infrastructure/persistence/RestaurantJpaRepository.java
+++ b/src/main/java/com/michelet/restaurantservice/restaurant/infrastructure/persistence/RestaurantJpaRepository.java
@@ -4,9 +4,12 @@ import com.michelet.restaurantservice.restaurant.domain.model.Restaurant;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface RestaurantJpaRepository extends JpaRepository<Restaurant, UUID> {
 
     List<Restaurant> findAllByOwnerId(UUID ownerId);
+
+    Optional<Restaurant> findFirstByOwnerIdAndDeletedAtIsNull(UUID ownerId);
 }

--- a/src/main/java/com/michelet/restaurantservice/restaurant/infrastructure/persistence/RestaurantJpaRepository.java
+++ b/src/main/java/com/michelet/restaurantservice/restaurant/infrastructure/persistence/RestaurantJpaRepository.java
@@ -11,5 +11,5 @@ public interface RestaurantJpaRepository extends JpaRepository<Restaurant, UUID>
 
     List<Restaurant> findAllByOwnerId(UUID ownerId);
 
-    Optional<Restaurant> findFirstByOwnerIdAndDeletedAtIsNull(UUID ownerId);
+    Optional<Restaurant> findByOwnerIdAndDeletedAtIsNull(UUID ownerId);
 }

--- a/src/main/java/com/michelet/restaurantservice/restaurant/infrastructure/persistence/RestaurantRepositoryImpl.java
+++ b/src/main/java/com/michelet/restaurantservice/restaurant/infrastructure/persistence/RestaurantRepositoryImpl.java
@@ -31,4 +31,9 @@ public class RestaurantRepositoryImpl implements RestaurantRepository {
     public List<Restaurant> findAllByOwnerId(UUID ownerId) {
         return restaurantJpaRepository.findAllByOwnerId(ownerId);
     }
+
+    @Override
+    public Optional<Restaurant> findFirstByOwnerIdAndDeletedAtIsNull(UUID ownerId) {
+        return restaurantJpaRepository.findFirstByOwnerIdAndDeletedAtIsNull(ownerId);
+    }
 }

--- a/src/main/java/com/michelet/restaurantservice/restaurant/infrastructure/persistence/RestaurantRepositoryImpl.java
+++ b/src/main/java/com/michelet/restaurantservice/restaurant/infrastructure/persistence/RestaurantRepositoryImpl.java
@@ -33,7 +33,7 @@ public class RestaurantRepositoryImpl implements RestaurantRepository {
     }
 
     @Override
-    public Optional<Restaurant> findFirstByOwnerIdAndDeletedAtIsNull(UUID ownerId) {
-        return restaurantJpaRepository.findFirstByOwnerIdAndDeletedAtIsNull(ownerId);
+    public Optional<Restaurant> findByOwnerIdAndDeletedAtIsNull(UUID ownerId) {
+        return restaurantJpaRepository.findByOwnerIdAndDeletedAtIsNull(ownerId);
     }
 }

--- a/src/main/java/com/michelet/restaurantservice/restaurant/presentation/controller/internal/RestaurantInternalController.java
+++ b/src/main/java/com/michelet/restaurantservice/restaurant/presentation/controller/internal/RestaurantInternalController.java
@@ -4,6 +4,7 @@ import com.michelet.common.response.ApiResponse;
 import com.michelet.restaurantservice.restaurant.application.result.GetRestaurantResult;
 import com.michelet.restaurantservice.restaurant.application.service.RestaurantQueryService;
 import com.michelet.restaurantservice.restaurant.presentation.dto.GetInternalRestaurantResponse;
+import com.michelet.restaurantservice.restaurant.presentation.dto.GetOwnerRestaurantIdResponse;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -32,5 +33,12 @@ public class RestaurantInternalController {
         GetRestaurantResult result = restaurantQueryService.getRestaurant(restaurantId);
 
         return ApiResponse.ok(GetInternalRestaurantResponse.from(result));
+    }
+
+    @GetMapping("/owners/{ownerId}/id")
+    public ApiResponse<GetOwnerRestaurantIdResponse> getOwnerRestaurantId(@PathVariable UUID ownerId) {
+        UUID restaurantId = restaurantQueryService.getRestaurantIdByOwnerId(ownerId);
+
+        return ApiResponse.ok(GetOwnerRestaurantIdResponse.from(restaurantId));
     }
 }

--- a/src/main/java/com/michelet/restaurantservice/restaurant/presentation/dto/GetOwnerRestaurantIdResponse.java
+++ b/src/main/java/com/michelet/restaurantservice/restaurant/presentation/dto/GetOwnerRestaurantIdResponse.java
@@ -1,0 +1,12 @@
+package com.michelet.restaurantservice.restaurant.presentation.dto;
+
+import java.util.UUID;
+
+public record GetOwnerRestaurantIdResponse(
+        UUID restaurantId
+) {
+
+    public static GetOwnerRestaurantIdResponse from(UUID restaurantId) {
+        return new GetOwnerRestaurantIdResponse(restaurantId);
+    }
+}

--- a/src/test/http/restaurant-internal.http
+++ b/src/test/http/restaurant-internal.http
@@ -1,0 +1,59 @@
+### 공통 변수
+@gatewayUrl = http://localhost:19000
+@restaurantServiceUrl = http://localhost:19300
+@orderUrl = http://localhost:19700
+
+### 테스트 ownerId
+### DB에서 실제 존재하는 owner_id로 교체
+@ownerId = 4c7089d7-4252-42c4-baeb-16df65c0eba3
+
+
+### 1. restaurant-service 호출용 내부 토큰 발급
+### 기존 MVP http 파일에서 사용하던 테스트 토큰 발급 API 재사용
+GET {{orderUrl}}/test/internal-token?audience=restaurant-service
+
+> {%
+    client.global.clear("restaurantInternalToken");
+
+    if (response.body) {
+        client.global.set("restaurantInternalToken", response.body);
+        client.log("Saved restaurant internal token");
+    }
+%}
+
+
+### 2. 점주 소유 식당 ID 조회 - restaurant-service 직접 호출
+GET {{restaurantServiceUrl}}/internal/v1/restaurants/owners/{{ownerId}}/id
+X-Internal-Token: {{restaurantInternalToken}}
+Content-Type: application/json
+
+> {%
+    client.test("점주 소유 식당 ID 조회 성공", function () {
+        client.assert(response.status === 200, "Expected 200 OK but got " + response.status);
+        client.assert(response.body !== undefined, "response body 없음");
+        client.assert(response.body.data !== undefined, "response.data 없음");
+        client.assert(response.body.data.restaurantId !== undefined, "restaurantId 없음");
+    });
+
+    if (response.body && response.body.data && response.body.data.restaurantId) {
+        client.global.set("restaurantId", response.body.data.restaurantId);
+        client.log("Saved restaurantId: " + response.body.data.restaurantId);
+    }
+%}
+
+### 3. 점주 소유 식당 ID 조회 - 식당 없음
+@notFoundOwnerId = 99999999-9999-9999-9999-999999999999
+
+GET {{restaurantServiceUrl}}/internal/v1/restaurants/owners/{{notFoundOwnerId}}/id
+X-Internal-Token: {{restaurantInternalToken}}
+Content-Type: application/json
+
+> {%
+    client.test("점주 소유 식당이 없으면 404 응답", function () {
+        client.assert(response.status === 404, "Expected 404 but got " + response.status);
+    });
+
+    if (response.body) {
+        client.log("not found response body: " + JSON.stringify(response.body));
+    }
+%}

--- a/src/test/http/restaurant-internal.http
+++ b/src/test/http/restaurant-internal.http
@@ -51,6 +51,12 @@ Content-Type: application/json
 > {%
     client.test("점주 소유 식당이 없으면 404 응답", function () {
         client.assert(response.status === 404, "Expected 404 but got " + response.status);
+        client.assert(response.body !== undefined, "response body 없음");
+        client.assert(response.body.success === false, "success=false 여야 함");
+        client.assert(
+            response.body.code === "RESTAURANT_404_NOT_FOUND",
+            "Expected RESTAURANT_404_NOT_FOUND but got " + response.body.code
+        );
     });
 
     if (response.body) {


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.

- restaurant-service에 점주 ownerId 기준으로 소유 식당의 restaurantId를 조회하는 내부 API를 추가
- order-service 등 내부 서비스에서 ownerId만 알고 있는 경우 restaurantId를 식별할 수 있도록 지원
- 삭제된 식당은 조회되지 않도록 `deletedAt IS NULL` 조건을 적용
- 식당이 존재하지 않는 경우 기존 식당 도메인 예외를 사용해 `RESTAURANT_404_NOT_FOUND`를 반환하도록 처리

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #29 
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to # 

## ✅ 자체 체크리스트 (필수)
- [x] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [x] IntelliJ HTTP Client 테스트 완료 (인증샷 첨부)
- [x] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [x] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 IntelliJ HTTP Client 실행 화면을 여기에 첨부해 주세요.

<img width="1126" height="466" alt="스크린샷 2026-05-08 171928" src="https://github.com/user-attachments/assets/c6e64a9d-b15d-4c51-936b-32584ef19c59" />
<img width="1341" height="479" alt="스크린샷 2026-05-08 172004" src="https://github.com/user-attachments/assets/8a0779ab-7897-4528-b8b3-321dc4c668cd" />
<img width="1523" height="213" alt="스크린샷 2026-05-08 172951" src="https://github.com/user-attachments/assets/0aa90fcf-eff5-446d-8e2b-fe4603ded442" />


## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.
> - [ ] 논의점
<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 소유자 ID를 통해 레스토랑 ID를 조회하는 새로운 내부 API 엔드포인트를 추가했습니다. 기존 소유자에 연결된 레스토랑의 ID를 반환하며, 해당하는 레스토랑이 없으면 404 에러를 반환합니다.

* **테스트**
  * 새로운 내부 API 엔드포인트에 대한 통합 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->