### PR TITLE
[CHORE] 식당 조회 API As-Is 부하테스트 추가

### DIFF
--- a/load-tests/restaurant/restaurant-read-as-is.js
+++ b/load-tests/restaurant/restaurant-read-as-is.js
@@ -1,0 +1,108 @@
+import http from 'k6/http';
+import { check, group, sleep } from 'k6';
+
+export const options = {
+    vus: Number(__ENV.VUS || 10),
+    duration: __ENV.DURATION || '1m',
+
+    thresholds: {
+        http_req_failed: ['rate<0.05'],
+    },
+
+    summaryTrendStats: ['avg', 'min', 'med', 'p(90)', 'p(95)', 'p(99)', 'max'],
+};
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:19000';
+const RESTAURANT_ID = __ENV.RESTAURANT_ID;
+
+const AUTH_TOKEN = __ENV.AUTH_TOKEN;
+
+const KEYWORD = __ENV.KEYWORD || '';
+const REGION = __ENV.REGION || '';
+const STATUS = __ENV.STATUS || 'OPEN';
+const PAGE = __ENV.PAGE || '0';
+const SIZE = __ENV.SIZE || '10';
+
+const DEBUG = __ENV.DEBUG === 'true';
+
+if (!RESTAURANT_ID) {
+    throw new Error('RESTAURANT_ID 환경변수는 필수입니다.');
+}
+
+if (!AUTH_TOKEN) {
+    throw new Error('AUTH_TOKEN 환경변수는 필수입니다.');
+}
+
+function requestParams(apiName) {
+    return {
+        headers: {
+            Authorization: `Bearer ${AUTH_TOKEN}`,
+        },
+        tags: {
+            api: apiName,
+        },
+    };
+}
+
+function debugResponse(apiName, response) {
+    if (!DEBUG) {
+        return;
+    }
+
+    console.log(`[${apiName}] status=${response.status}`);
+    console.log(`[${apiName}] body=${response.body}`);
+}
+
+export default function () {
+    group('식당 상세 조회', function () {
+        const response = http.get(
+            `${BASE_URL}/api/v1/restaurants/${RESTAURANT_ID}`,
+            requestParams('restaurant-detail')
+        );
+
+        debugResponse('식당 상세 조회', response);
+
+        check(response, {
+            '식당 상세 조회 status 200': (res) => res.status === 200,
+            '식당 상세 조회 응답 body 존재': (res) => !!res.body,
+        });
+    });
+
+    group('코스 목록 조회', function () {
+        const response = http.get(
+            `${BASE_URL}/api/v1/restaurants/${RESTAURANT_ID}/courses`,
+            requestParams('restaurant-courses')
+        );
+
+        debugResponse('코스 목록 조회', response);
+
+        check(response, {
+            '코스 목록 조회 status 200': (res) => res.status === 200,
+            '코스 목록 조회 응답 body 존재': (res) => !!res.body,
+        });
+    });
+
+    group('식당 목록 검색 조회', function () {
+        const queryString = [
+            `keyword=${encodeURIComponent(KEYWORD)}`,
+            `region=${encodeURIComponent(REGION)}`,
+            `status=${encodeURIComponent(STATUS)}`,
+            `page=${encodeURIComponent(PAGE)}`,
+            `size=${encodeURIComponent(SIZE)}`,
+        ].join('&');
+
+        const response = http.get(
+            `${BASE_URL}/api/v1/restaurants?${queryString}`,
+            requestParams('restaurant-search')
+        );
+
+        debugResponse('식당 목록 검색 조회', response);
+
+        check(response, {
+            '식당 목록 검색 조회 status 200': (res) => res.status === 200,
+            '식당 목록 검색 조회 응답 body 존재': (res) => !!res.body,
+        });
+    });
+
+    sleep(1);
+}

--- a/load-tests/restaurant/restaurant-read-as-is.js
+++ b/load-tests/restaurant/restaurant-read-as-is.js
@@ -12,9 +12,8 @@ export const options = {
     summaryTrendStats: ['avg', 'min', 'med', 'p(90)', 'p(95)', 'p(99)', 'max'],
 };
 
-const BASE_URL = __ENV.BASE_URL || 'http://localhost:19000';
+const BASE_URL = __ENV.BASE_URL;
 const RESTAURANT_ID = __ENV.RESTAURANT_ID;
-
 const AUTH_TOKEN = __ENV.AUTH_TOKEN;
 
 const KEYWORD = __ENV.KEYWORD || '';
@@ -24,6 +23,10 @@ const PAGE = __ENV.PAGE || '0';
 const SIZE = __ENV.SIZE || '10';
 
 const DEBUG = __ENV.DEBUG === 'true';
+
+if (!BASE_URL) {
+    throw new Error('BASE_URL 환경변수는 필수입니다.');
+}
 
 if (!RESTAURANT_ID) {
     throw new Error('RESTAURANT_ID 환경변수는 필수입니다.');
@@ -49,8 +52,10 @@ function debugResponse(apiName, response) {
         return;
     }
 
+    const bodyPreview = response.body ? response.body.substring(0, 300) : '';
+
     console.log(`[${apiName}] status=${response.status}`);
-    console.log(`[${apiName}] body=${response.body}`);
+    console.log(`[${apiName}] bodyPreview=${bodyPreview}`);
 }
 
 export default function () {


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.

- restaurant-service 조회 API의 Redis 캐시 적용 전 As-Is 부하테스트를 위한 k6 스크립트를 추가
- 식당 상세 조회, 코스 목록 조회, 식당 목록 검색 조회 API를 대상으로 VUS 10 / 1분 부하테스트를 수행



## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #33 
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to # 

## ✅ 자체 체크리스트 (필수)
- [ ] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [ ] IntelliJ HTTP Client 테스트 완료 (인증샷 첨부)
- [ ] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [ ] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 IntelliJ HTTP Client 실행 화면을 여기에 첨부해 주세요.

<img width="1101" height="832" alt="스크린샷 2026-05-11 120618" src="https://github.com/user-attachments/assets/a659e430-5c3c-4d10-8018-ed1b3cae174e" />


## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.
> - [ ] 논의점

- 이번 PR은 성능 측정 스크립트와 As-Is 결과 기록만 포함
- 현재 결과는 식당 상세 조회, 코스 목록 조회, 식당 목록 검색 조회를 합산한 통합 지표
- API별 병목을 더 정확히 확인하기 위해 후속 이슈에서 API별 지표 분리 및 VUS 30 재측정을 진행할 예정
- Redis 캐시 적용 여부와 우선순위는 후속 부하테스트 결과를 기준으로 결정

<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경사항

* **테스트**
  * 식당 조회 API에 대한 부하 테스트 스크립트 추가. 환경 변수 기반 구성, 성능 임계값 설정, 및 응답 검증 포함.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Miche-Let/restaurant-service/pull/35)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->