### PR TITLE
[FEAT] 식당 상세 및 코스 목록 Redis 캐시 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,8 @@ dependencies {
     implementation 'com.github.Miche-Let:common-auth-feign:0.1.2'
     implementation 'com.github.Miche-Let:common-auth-webmvc:0.1.5'
     implementation 'org.springframework.kafka:spring-kafka'
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     runtimeOnly 'org.postgresql:postgresql'
 

--- a/src/main/java/com/michelet/restaurantservice/course/application/service/RestaurantCourseQueryService.java
+++ b/src/main/java/com/michelet/restaurantservice/course/application/service/RestaurantCourseQueryService.java
@@ -10,6 +10,7 @@ import com.michelet.restaurantservice.course.domain.model.RestaurantCourseMenu;
 import com.michelet.restaurantservice.course.domain.repository.RestaurantCourseMenuRepository;
 import com.michelet.restaurantservice.course.domain.repository.RestaurantCourseRepository;
 import com.michelet.restaurantservice.restaurant.domain.repository.RestaurantRepository;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -31,6 +32,7 @@ public class RestaurantCourseQueryService {
         this.restaurantCourseMenuRepository = restaurantCourseMenuRepository;
     }
 
+    @Cacheable(cacheNames = "restaurantCourses", key = "'restaurant:courses:' + #restaurantId")
     @Transactional(readOnly = true)
     public List<CourseListItemResult> getCourses(UUID restaurantId) {
         // 코스 목록 조회 전에 식당 존재 여부를 먼저 검증

--- a/src/main/java/com/michelet/restaurantservice/global/config/CacheConfig.java
+++ b/src/main/java/com/michelet/restaurantservice/global/config/CacheConfig.java
@@ -41,6 +41,7 @@ public class CacheConfig {
     public RedisCacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
         RedisCacheConfiguration defaultCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
                 .disableCachingNullValues()
+                .disableKeyPrefix()
                 .serializeKeysWith(
                         RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer())
                 )

--- a/src/main/java/com/michelet/restaurantservice/global/config/CacheConfig.java
+++ b/src/main/java/com/michelet/restaurantservice/global/config/CacheConfig.java
@@ -73,7 +73,7 @@ public class CacheConfig {
 
         objectMapper.activateDefaultTyping(
                 LaissezFaireSubTypeValidator.instance,
-                ObjectMapper.DefaultTyping.NON_FINAL,
+                ObjectMapper.DefaultTyping.EVERYTHING,
                 JsonTypeInfo.As.PROPERTY
         );
 

--- a/src/main/java/com/michelet/restaurantservice/global/config/CacheConfig.java
+++ b/src/main/java/com/michelet/restaurantservice/global/config/CacheConfig.java
@@ -1,0 +1,83 @@
+package com.michelet.restaurantservice.global.config;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+import java.util.Map;
+
+@EnableCaching
+@Configuration
+@EnableConfigurationProperties(CacheTtlProperties.class)
+public class CacheConfig {
+
+    private static final long DEFAULT_CACHE_TTL_SECONDS = 300L;
+
+    private final CacheTtlProperties cacheTtlProperties;
+
+    public CacheConfig(CacheTtlProperties cacheTtlProperties) {
+        this.cacheTtlProperties = cacheTtlProperties;
+    }
+
+
+    // Redis 기반 Spring CacheManager를 설정
+    // restaurantDetail: 식당 상세 조회
+    // restaurantCourses: 코스 목록 조회
+    @Bean
+    public RedisCacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
+        RedisCacheConfiguration defaultCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+                .disableCachingNullValues()
+                .serializeKeysWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer())
+                )
+                .serializeValuesWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(redisValueSerializer())
+                )
+                .entryTtl(Duration.ofSeconds(DEFAULT_CACHE_TTL_SECONDS));
+
+        Map<String, RedisCacheConfiguration> cacheConfigurations = Map.of(
+                "restaurantDetail",
+                defaultCacheConfiguration.entryTtl(Duration.ofSeconds(cacheTtlProperties.restaurantDetail())),
+
+                "restaurantCourses",
+                defaultCacheConfiguration.entryTtl(Duration.ofSeconds(cacheTtlProperties.restaurantCourses()))
+        );
+
+        return RedisCacheManager.builder(redisConnectionFactory)
+                .cacheDefaults(defaultCacheConfiguration)
+                .withInitialCacheConfigurations(cacheConfigurations)
+                .build();
+    }
+
+    // Redis value 직렬화 방식을 설정
+    private GenericJackson2JsonRedisSerializer redisValueSerializer() {
+        ObjectMapper objectMapper = JsonMapper.builder()
+                .addModule(new JavaTimeModule())
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .build();
+
+        objectMapper.activateDefaultTyping(
+                LaissezFaireSubTypeValidator.instance,
+                ObjectMapper.DefaultTyping.NON_FINAL,
+                JsonTypeInfo.As.PROPERTY
+        );
+
+        return new GenericJackson2JsonRedisSerializer(objectMapper);
+    }
+
+}

--- a/src/main/java/com/michelet/restaurantservice/global/config/CacheConfig.java
+++ b/src/main/java/com/michelet/restaurantservice/global/config/CacheConfig.java
@@ -4,7 +4,8 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
-import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cache.annotation.EnableCaching;
@@ -71,8 +72,15 @@ public class CacheConfig {
                 .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
                 .build();
 
+        PolymorphicTypeValidator typeValidator = BasicPolymorphicTypeValidator.builder()
+                .allowIfSubType("com.michelet.restaurantservice.")
+                .allowIfSubType("java.util.")
+                .allowIfSubType("java.time.")
+                .allowIfSubType("java.lang.")
+                .build();
+
         objectMapper.activateDefaultTyping(
-                LaissezFaireSubTypeValidator.instance,
+                typeValidator,
                 ObjectMapper.DefaultTyping.EVERYTHING,
                 JsonTypeInfo.As.PROPERTY
         );

--- a/src/main/java/com/michelet/restaurantservice/global/config/CacheConfig.java
+++ b/src/main/java/com/michelet/restaurantservice/global/config/CacheConfig.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/com/michelet/restaurantservice/global/config/CacheTtlProperties.java
+++ b/src/main/java/com/michelet/restaurantservice/global/config/CacheTtlProperties.java
@@ -1,0 +1,10 @@
+package com.michelet.restaurantservice.global.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "cache.ttl")
+public record CacheTtlProperties(
+        long restaurantDetail,
+        long restaurantCourses
+) {
+}

--- a/src/main/java/com/michelet/restaurantservice/global/config/CacheTtlProperties.java
+++ b/src/main/java/com/michelet/restaurantservice/global/config/CacheTtlProperties.java
@@ -1,10 +1,16 @@
 package com.michelet.restaurantservice.global.config;
 
+import jakarta.validation.constraints.Positive;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
 
+@Validated
 @ConfigurationProperties(prefix = "cache.ttl")
 public record CacheTtlProperties(
+        @Positive
         long restaurantDetail,
+
+        @Positive
         long restaurantCourses
 ) {
 }

--- a/src/main/java/com/michelet/restaurantservice/restaurant/application/service/RestaurantQueryService.java
+++ b/src/main/java/com/michelet/restaurantservice/restaurant/application/service/RestaurantQueryService.java
@@ -10,6 +10,7 @@ import com.michelet.restaurantservice.restaurant.domain.exception.RestaurantExce
 import com.michelet.restaurantservice.restaurant.domain.model.Restaurant;
 import com.michelet.restaurantservice.course.domain.repository.RestaurantCourseRepository;
 import com.michelet.restaurantservice.restaurant.domain.repository.RestaurantRepository;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -38,6 +39,7 @@ public class RestaurantQueryService {
      * 외부 상세 조회 API / 내부 조회 API에서 공통으로 사용하는 조회 메서드
      * 식당이 존재하지 않으면 RESTAURANT_404_NOT_FOUND 예외던짐
      */
+    @Cacheable(cacheNames = "restaurantDetail", key = "'restaurant:detail:' + #restaurantId")
     @Transactional(readOnly = true)
     public GetRestaurantResult getRestaurant(UUID restaurantId) {
         Restaurant restaurant = restaurantRepository.findById(restaurantId)

--- a/src/main/java/com/michelet/restaurantservice/restaurant/application/service/RestaurantQueryService.java
+++ b/src/main/java/com/michelet/restaurantservice/restaurant/application/service/RestaurantQueryService.java
@@ -40,7 +40,6 @@ public class RestaurantQueryService {
      * 식당이 존재하지 않으면 RESTAURANT_404_NOT_FOUND 예외던짐
      */
     @Cacheable(cacheNames = "restaurantDetail", key = "'restaurant:detail:' + #restaurantId")
-    @Transactional(readOnly = true)
     public GetRestaurantResult getRestaurant(UUID restaurantId) {
         Restaurant restaurant = restaurantRepository.findById(restaurantId)
                 .orElseThrow(() -> new RestaurantException(RestaurantErrorCode.RESTAURANT_404_NOT_FOUND));

--- a/src/main/resources/application-docker.yml
+++ b/src/main/resources/application-docker.yml
@@ -28,6 +28,11 @@ spring:
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS}
 
+  data:
+    redis:
+      host: ${REDIS_HOST:redis}
+      port: ${REDIS_PORT:6379}
+
 eureka:
   client:
     enabled: ${EUREKA_CLIENT_ENABLED:true}

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -30,6 +30,11 @@ spring:
     consumer:
       auto-offset-reset: earliest
 
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+
 eureka:
   client:
     enabled: ${EUREKA_CLIENT_ENABLED:false}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -15,6 +15,9 @@ spring:
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
 
+  cache:
+    type: redis
+
 server:
   port: ${SERVER_PORT:19300}
 
@@ -38,3 +41,8 @@ feign:
 kafka:
   topic:
     reservation-check-in-completed: reservation.check-in.completed
+
+cache:
+  ttl:
+    restaurant-detail: ${CACHE_TTL_RESTAURANT_DETAIL:300}
+    restaurant-courses: ${CACHE_TTL_RESTAURANT_COURSES:300}

--- a/src/test/http/restaurant-cache.http
+++ b/src/test/http/restaurant-cache.http
@@ -1,0 +1,178 @@
+### 공통 변수
+@gatewayUrl = http://localhost:19000
+
+### 테스트 OWNER 계정
+@ownerLoginId = test90212
+@ownerPassword = test123!0212
+@ownerName = owner90212
+@ownerEmail = owner0090212@naver.com
+@ownerPhone = 010-0000-1013
+
+
+### 1. OWNER 회원가입
+POST {{gatewayUrl}}/api/v1/users/signup
+Content-Type: application/json
+
+{
+  "loginId": "{{ownerLoginId}}",
+  "password": "{{ownerPassword}}",
+  "name": "{{ownerName}}",
+  "email": "{{ownerEmail}}",
+  "phone": "{{ownerPhone}}",
+  "userRole": "OWNER"
+}
+
+
+### 2. OWNER 로그인
+POST {{gatewayUrl}}/api/v1/auth/login
+Content-Type: application/json
+
+{
+  "loginId": "{{ownerLoginId}}",
+  "password": "{{ownerPassword}}"
+}
+
+> {%
+    client.global.clear("ownerToken");
+
+    let token = null;
+
+    if (response.body.data && response.body.data.accessToken) {
+        token = response.body.data.accessToken;
+    } else if (response.body.data && response.body.data.token) {
+        token = response.body.data.token;
+    } else if (response.body.accessToken) {
+        token = response.body.accessToken;
+    } else if (response.body.token) {
+        token = response.body.token;
+    }
+
+    if (token) {
+        client.global.set("ownerToken", token);
+        client.log("Saved ownerToken");
+    }
+%}
+
+
+### 3. 식당 등록
+POST {{gatewayUrl}}/api/v1/restaurants
+Content-Type: application/json
+Authorization: Bearer {{ownerToken}}
+
+{
+  "name": "Redis Cache Test Dining",
+  "address": "서울특별시 강남구 테헤란로 123",
+  "phone": "02-1234-5678",
+  "description": "Redis 캐시 검증용 파인다이닝 레스토랑",
+  "reservationOpenAt": "10:00:00",
+  "avgMealDurationMin": 90,
+  "status": "OPEN",
+  "businessHours": "MON-FRI 11:00-20:00 / SAT,SUN CLOSED"
+}
+
+> {%
+    client.global.clear("restaurantId");
+
+    if (response.body.data && response.body.data.restaurantId) {
+        client.global.set("restaurantId", response.body.data.restaurantId);
+        client.log("Saved restaurantId: " + response.body.data.restaurantId);
+    }
+%}
+
+
+### 4. 코스 등록
+POST {{gatewayUrl}}/api/v1/restaurants/{{restaurantId}}/courses
+Content-Type: application/json
+Authorization: Bearer {{ownerToken}}
+
+{
+  "name": "Redis Cache Test Dinner Course",
+  "price": 150000,
+  "sessionType": "DINNER",
+  "status": "AVAILABLE",
+  "menus": [
+    {
+      "coursePart": "AMUSE_BOUCHE",
+      "menuName": "한우 타르타르",
+      "sortOrder": 1
+    },
+    {
+      "coursePart": "APPETIZER",
+      "menuName": "제철 샐러드",
+      "sortOrder": 2
+    },
+    {
+      "coursePart": "FISH",
+      "menuName": "제철 생선 구이",
+      "sortOrder": 3
+    },
+    {
+      "coursePart": "MAIN",
+      "menuName": "양갈비",
+      "sortOrder": 4
+    },
+    {
+      "coursePart": "DESSERT",
+      "menuName": "바닐라 무스",
+      "sortOrder": 5
+    }
+  ]
+}
+
+
+### 5. 식당 상세 조회 - 1차 호출
+GET {{gatewayUrl}}/api/v1/restaurants/{{restaurantId}}
+Authorization: Bearer {{ownerToken}}
+Content-Type: application/json
+
+> {%
+    client.test("식당 상세 조회 1차 호출 성공", function () {
+        client.assert(response.status === 200, "Expected 200 but got " + response.status);
+        client.assert(response.body.success === true, "success 값이 true가 아님");
+    });
+
+    client.log("상세 캐시 key 확인:");
+    client.log("restaurant:detail:" + client.global.get("restaurantId"));
+%}
+
+
+### 6. 식당 상세 조회 - 2차 호출
+GET {{gatewayUrl}}/api/v1/restaurants/{{restaurantId}}
+Authorization: Bearer {{ownerToken}}
+Content-Type: application/json
+
+> {%
+    client.test("식당 상세 조회 2차 호출 성공", function () {
+        client.assert(response.status === 200, "Expected 200 but got " + response.status);
+        client.assert(response.body.success === true, "success 값이 true가 아님");
+    });
+%}
+
+
+### 7. 코스 목록 조회 - 1차 호출
+GET {{gatewayUrl}}/api/v1/restaurants/{{restaurantId}}/courses
+Authorization: Bearer {{ownerToken}}
+Content-Type: application/json
+
+> {%
+    client.test("코스 목록 조회 1차 호출 성공", function () {
+        client.assert(response.status === 200, "Expected 200 but got " + response.status);
+        client.assert(response.body.success === true, "success 값이 true가 아님");
+    });
+
+    client.log("코스 캐시 key 확인:");
+    client.log("restaurant:courses:" + client.global.get("restaurantId"));
+%}
+
+
+### 8. 코스 목록 조회 - 2차 호출
+GET {{gatewayUrl}}/api/v1/restaurants/{{restaurantId}}/courses
+Authorization: Bearer {{ownerToken}}
+Content-Type: application/json
+
+> {%
+    client.test("코스 목록 조회 2차 호출 성공", function () {
+        client.assert(response.status === 200, "Expected 200 but got " + response.status);
+        client.assert(response.body.success === true, "success 값이 true가 아님");
+    });
+%}

--- a/src/test/java/com/michelet/restaurantservice/course/application/service/RestaurantCourseQueryServiceCacheTest.java
+++ b/src/test/java/com/michelet/restaurantservice/course/application/service/RestaurantCourseQueryServiceCacheTest.java
@@ -1,0 +1,144 @@
+package com.michelet.restaurantservice.course.application.service;
+
+import com.michelet.restaurantservice.course.domain.repository.RestaurantCourseMenuRepository;
+import com.michelet.restaurantservice.course.domain.repository.RestaurantCourseRepository;
+import com.michelet.restaurantservice.restaurant.domain.model.Restaurant;
+import com.michelet.restaurantservice.restaurant.domain.model.RestaurantStatus;
+import com.michelet.restaurantservice.restaurant.domain.repository.RestaurantRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.context.annotation.Bean;
+
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+@SpringBootTest(classes = {
+        RestaurantCourseQueryService.class,
+        RestaurantCourseQueryServiceCacheTest.CacheTestConfig.class
+})
+class RestaurantCourseQueryServiceCacheTest {
+
+    private final RestaurantCourseQueryService restaurantCourseQueryService;
+    private final RestaurantRepository restaurantRepository;
+    private final RestaurantCourseRepository restaurantCourseRepository;
+    private final RestaurantCourseMenuRepository restaurantCourseMenuRepository;
+    private final CacheManager cacheManager;
+
+    @Autowired
+    RestaurantCourseQueryServiceCacheTest(
+            RestaurantCourseQueryService restaurantCourseQueryService,
+            RestaurantRepository restaurantRepository,
+            RestaurantCourseRepository restaurantCourseRepository,
+            RestaurantCourseMenuRepository restaurantCourseMenuRepository,
+            CacheManager cacheManager
+    ) {
+        this.restaurantCourseQueryService = restaurantCourseQueryService;
+        this.restaurantRepository = restaurantRepository;
+        this.restaurantCourseRepository = restaurantCourseRepository;
+        this.restaurantCourseMenuRepository = restaurantCourseMenuRepository;
+        this.cacheManager = cacheManager;
+    }
+
+    @AfterEach
+    void tearDown() {
+        Cache restaurantCoursesCache = cacheManager.getCache("restaurantCourses");
+
+        if (restaurantCoursesCache != null) {
+            restaurantCoursesCache.clear();
+        }
+
+        Mockito.reset(
+                restaurantRepository,
+                restaurantCourseRepository,
+                restaurantCourseMenuRepository
+        );
+    }
+
+    @Test
+    @DisplayName("코스 목록 조회는 동일 restaurantId로 재조회 시 캐시를 사용한다")
+    void 코스목록조회는동일RestaurantId로재조회시캐시를사용한다() {
+        UUID restaurantId = UUID.randomUUID();
+
+        Restaurant restaurant = Restaurant.create(
+                UUID.randomUUID(),
+                "Redis Cache Test Dining",
+                "서울특별시 강남구 테헤란로 123",
+                "02-1234-5678",
+                "Redis 캐시 테스트용 식당",
+                LocalTime.of(10, 0),
+                90,
+                RestaurantStatus.OPEN,
+                "MON-FRI 11:00-20:00 / SAT,SUN CLOSED"
+        );
+
+        given(restaurantRepository.findById(restaurantId))
+                .willReturn(Optional.of(restaurant));
+
+        given(restaurantCourseRepository.findAllByRestaurantIdOrderByCreatedAtAsc(restaurantId))
+                .willReturn(List.of());
+
+        // 첫 번째 호출: cache miss → 식당 존재 검증 및 코스 목록 조회 발생
+        var firstResult = restaurantCourseQueryService.getCourses(restaurantId);
+
+        // 두 번째 호출: cache hit → repository 조회가 다시 발생하면 안 됨
+        var secondResult = restaurantCourseQueryService.getCourses(restaurantId);
+
+        // cache hit 결과가 최초 조회 결과와 동일한지 확인
+        assertThat(secondResult).isEqualTo(firstResult);
+
+        then(restaurantRepository)
+                .should(times(1))
+                .findById(restaurantId);
+
+        then(restaurantCourseRepository)
+                .should(times(1))
+                .findAllByRestaurantIdOrderByCreatedAtAsc(restaurantId);
+
+        // 코스가 없는 경우에는 메뉴 조회를 수행X
+        then(restaurantCourseMenuRepository)
+                .should(never())
+                .findAllByCourseIdInOrderByCourseIdAscSortOrderAsc(Mockito.anyList());
+    }
+
+    @EnableCaching
+    @TestConfiguration
+    static class CacheTestConfig {
+
+        @Bean
+        CacheManager cacheManager() {
+            return new ConcurrentMapCacheManager("restaurantCourses");
+        }
+
+        @Bean
+        RestaurantRepository restaurantRepository() {
+            return Mockito.mock(RestaurantRepository.class);
+        }
+
+        @Bean
+        RestaurantCourseRepository restaurantCourseRepository() {
+            return Mockito.mock(RestaurantCourseRepository.class);
+        }
+
+        @Bean
+        RestaurantCourseMenuRepository restaurantCourseMenuRepository() {
+            return Mockito.mock(RestaurantCourseMenuRepository.class);
+        }
+    }
+}

--- a/src/test/java/com/michelet/restaurantservice/restaurant/application/service/RestaurantQueryServiceCacheTest.java
+++ b/src/test/java/com/michelet/restaurantservice/restaurant/application/service/RestaurantQueryServiceCacheTest.java
@@ -1,0 +1,127 @@
+package com.michelet.restaurantservice.restaurant.application.service;
+
+import com.michelet.restaurantservice.course.domain.repository.RestaurantCourseRepository;
+import com.michelet.restaurantservice.restaurant.application.query.repository.RestaurantQueryRepository;
+import com.michelet.restaurantservice.restaurant.domain.model.Restaurant;
+import com.michelet.restaurantservice.restaurant.domain.model.RestaurantStatus;
+import com.michelet.restaurantservice.restaurant.domain.repository.RestaurantRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.context.annotation.Bean;
+
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
+@SpringBootTest(classes = {
+        RestaurantQueryService.class,
+        RestaurantQueryServiceCacheTest.CacheTestConfig.class
+})
+class RestaurantQueryServiceCacheTest {
+
+    private final RestaurantQueryService restaurantQueryService;
+    private final RestaurantRepository restaurantRepository;
+    private final RestaurantCourseRepository restaurantCourseRepository;
+    private final CacheManager cacheManager;
+
+    @Autowired
+    RestaurantQueryServiceCacheTest(
+            RestaurantQueryService restaurantQueryService,
+            RestaurantRepository restaurantRepository,
+            RestaurantCourseRepository restaurantCourseRepository,
+            CacheManager cacheManager
+    ) {
+        this.restaurantQueryService = restaurantQueryService;
+        this.restaurantRepository = restaurantRepository;
+        this.restaurantCourseRepository = restaurantCourseRepository;
+        this.cacheManager = cacheManager;
+    }
+
+    @AfterEach
+    void tearDown() {
+        Cache restaurantDetailCache = cacheManager.getCache("restaurantDetail");
+
+        if (restaurantDetailCache != null) {
+            restaurantDetailCache.clear();
+        }
+
+        Mockito.reset(restaurantRepository, restaurantCourseRepository);
+    }
+
+    @Test
+    @DisplayName("식당 상세 조회는 동일 restaurantId로 재조회 시 캐시를 사용한다")
+    void 식당상세조회는동일RestaurantId로재조회시캐시를사용한다() {
+        UUID restaurantId = UUID.randomUUID();
+
+        Restaurant restaurant = Restaurant.create(
+                UUID.randomUUID(),
+                "Redis Cache Test Dining",
+                "서울특별시 강남구 테헤란로 123",
+                "02-1234-5678",
+                "Redis 캐시 테스트용 식당",
+                LocalTime.of(10, 0),
+                90,
+                RestaurantStatus.OPEN,
+                "MON-FRI 11:00-20:00 / SAT,SUN CLOSED"
+        );
+
+        given(restaurantRepository.findById(restaurantId))
+                .willReturn(Optional.of(restaurant));
+
+        given(restaurantCourseRepository.findAllByRestaurantIdOrderByCreatedAtAsc(restaurantId))
+                .willReturn(List.of());
+
+        // 첫 번째 호출: cache miss → repository 조회 발생
+        restaurantQueryService.getRestaurant(restaurantId);
+
+        // 두 번째 호출: cache hit → repository 조회가 다시 발생하면 안 됨
+        restaurantQueryService.getRestaurant(restaurantId);
+
+        then(restaurantRepository)
+                .should(times(1))
+                .findById(restaurantId);
+
+        then(restaurantCourseRepository)
+                .should(times(1))
+                .findAllByRestaurantIdOrderByCreatedAtAsc(restaurantId);
+    }
+
+    @EnableCaching
+    @TestConfiguration
+    static class CacheTestConfig {
+
+        @Bean
+        CacheManager cacheManager() {
+            return new ConcurrentMapCacheManager("restaurantDetail");
+        }
+
+        @Bean
+        RestaurantRepository restaurantRepository() {
+            return Mockito.mock(RestaurantRepository.class);
+        }
+
+        @Bean
+        RestaurantCourseRepository restaurantCourseRepository() {
+            return Mockito.mock(RestaurantCourseRepository.class);
+        }
+
+        @Bean
+        RestaurantQueryRepository restaurantQueryRepository() {
+            return Mockito.mock(RestaurantQueryRepository.class);
+        }
+    }
+}

--- a/src/test/java/com/michelet/restaurantservice/restaurant/application/service/RestaurantQueryServiceCacheTest.java
+++ b/src/test/java/com/michelet/restaurantservice/restaurant/application/service/RestaurantQueryServiceCacheTest.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.times;
@@ -91,10 +92,13 @@ class RestaurantQueryServiceCacheTest {
                 .willReturn(List.of());
 
         // 첫 번째 호출: cache miss → repository 조회 발생
-        restaurantQueryService.getRestaurant(restaurantId);
+        var firstResult = restaurantQueryService.getRestaurant(restaurantId);
 
         // 두 번째 호출: cache hit → repository 조회가 다시 발생하면 안 됨
-        restaurantQueryService.getRestaurant(restaurantId);
+        var secondResult = restaurantQueryService.getRestaurant(restaurantId);
+
+        // cache hit 결과가 최초 조회 결과와 동일한지 확인
+        assertThat(secondResult).isEqualTo(firstResult);
 
         then(restaurantRepository)
                 .should(times(1))

--- a/src/test/java/com/michelet/restaurantservice/restaurant/application/service/RestaurantQueryServiceCacheTest.java
+++ b/src/test/java/com/michelet/restaurantservice/restaurant/application/service/RestaurantQueryServiceCacheTest.java
@@ -54,9 +54,14 @@ class RestaurantQueryServiceCacheTest {
     @AfterEach
     void tearDown() {
         Cache restaurantDetailCache = cacheManager.getCache("restaurantDetail");
+        Cache restaurantCoursesCache = cacheManager.getCache("restaurantCourses");
 
         if (restaurantDetailCache != null) {
             restaurantDetailCache.clear();
+        }
+
+        if (restaurantCoursesCache != null) {
+            restaurantCoursesCache.clear();
         }
 
         Mockito.reset(restaurantRepository, restaurantCourseRepository);
@@ -106,7 +111,7 @@ class RestaurantQueryServiceCacheTest {
 
         @Bean
         CacheManager cacheManager() {
-            return new ConcurrentMapCacheManager("restaurantDetail");
+            return new ConcurrentMapCacheManager("restaurantDetail", "restaurantCourses");
         }
 
         @Bean


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.

- restaurant-service의 식당 상세 조회와 코스 목록 조회 API에 Redis 기반 read-through cache를 적용
- 캐시 대상은 반복 조회 가능성이 높은 read-heavy API인 아래 두 개로 제한
  - `GET /api/v1/restaurants/{restaurantId}`
  - `GET /api/v1/restaurants/{restaurantId}/courses`
- 검색 API는 key 조합이 많고 hit rate가 낮을 수 있어 이번 캐시 범위에서 제외
- Redis CacheManager 설정을 추가하고, 캐시별 TTL을 설정
- Redis 캐시 value 직렬화/역직렬화 과정에서 record DTO를 정상 처리할 수 있도록 serializer 설정을 보완
- `.http` 요청으로 Redis key 생성, TTL 적용, cache hit 시 DB 조회 미발생을 수동 검증
- 식당 상세 조회와 코스 목록 조회 캐시 테스트를 추가

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #40 
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to # 

## ✅ 자체 체크리스트 (필수)
- [ ] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [ ] IntelliJ HTTP Client 테스트 완료 (인증샷 첨부)
- [ ] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [ ] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 IntelliJ HTTP Client 실행 화면을 여기에 첨부해 주세요.

<img width="1035" height="158" alt="제목 없는 디자인" src="https://github.com/user-attachments/assets/ba114814-505a-4d34-a691-b529c6937448" />


## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.
> - [ ] 논의점

- docker logs -f --tail 0 restaurant-service로 로그를 비운 뒤 동일 API를 재호출
- 식당 상세 조회 2차 호출 시 Hibernate select 로그 미발생
- 코스 목록 조회 2차 호출 시 Hibernate select 로그 미발생 
- 검색 API는 key 조합이 많고 hit rate가 낮을 수 있어 캐시 적용 대상에서 제외했습니다 검색 성능 병목이 확인되면 인덱스/쿼리 최적화 이슈로 분리하는 것이 적절하다고 판단 
  

<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **Chores**
  * Redis 기반 캐싱 시스템 구축으로 식당 상세 정보 및 코스 목록 조회 성능 개선
  * 캐싱 구성 및 환경 설정 추가

* **Tests**
  * 캐싱 동작 검증을 위한 통합 테스트 및 E2E 테스트 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Miche-Let/restaurant-service/pull/41)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->