### PR TITLE
[FEAT] 점주 소유 식당 ID 응답에 ownerId 추가

### DIFF
--- a/src/main/java/com/michelet/restaurantservice/restaurant/presentation/controller/internal/RestaurantInternalController.java
+++ b/src/main/java/com/michelet/restaurantservice/restaurant/presentation/controller/internal/RestaurantInternalController.java
@@ -39,6 +39,6 @@ public class RestaurantInternalController {
     public ApiResponse<GetOwnerRestaurantIdResponse> getOwnerRestaurantId(@PathVariable UUID ownerId) {
         UUID restaurantId = restaurantQueryService.getRestaurantIdByOwnerId(ownerId);
 
-        return ApiResponse.ok(GetOwnerRestaurantIdResponse.from(restaurantId));
+        return ApiResponse.ok(GetOwnerRestaurantIdResponse.of(ownerId, restaurantId));
     }
 }

--- a/src/main/java/com/michelet/restaurantservice/restaurant/presentation/dto/GetOwnerRestaurantIdResponse.java
+++ b/src/main/java/com/michelet/restaurantservice/restaurant/presentation/dto/GetOwnerRestaurantIdResponse.java
@@ -3,10 +3,11 @@ package com.michelet.restaurantservice.restaurant.presentation.dto;
 import java.util.UUID;
 
 public record GetOwnerRestaurantIdResponse(
+        UUID ownerId,
         UUID restaurantId
 ) {
 
-    public static GetOwnerRestaurantIdResponse from(UUID restaurantId) {
-        return new GetOwnerRestaurantIdResponse(restaurantId);
+    public static GetOwnerRestaurantIdResponse of(UUID ownerId, UUID restaurantId) {
+        return new GetOwnerRestaurantIdResponse(ownerId, restaurantId);
     }
 }

--- a/src/test/http/restaurant-internal.http
+++ b/src/test/http/restaurant-internal.http
@@ -4,12 +4,15 @@
 @orderUrl = http://localhost:19700
 
 ### 테스트 ownerId
-### DB에서 실제 존재하는 owner_id로 교체
+### DB에 실제 존재하는 owner_id로 교체
 @ownerId = 4c7089d7-4252-42c4-baeb-16df65c0eba3
+
+### 존재하지 않는 ownerId
+@notFoundOwnerId = 99999999-9999-9999-9999-999999999999
 
 
 ### 1. restaurant-service 호출용 내부 토큰 발급
-### 기존 MVP http 파일에서 사용하던 테스트 토큰 발급 API 재사용
+### audience는 반드시 restaurant-service
 GET {{orderUrl}}/test/internal-token?audience=restaurant-service
 
 > {%
@@ -30,20 +33,27 @@ Content-Type: application/json
 > {%
     client.test("점주 소유 식당 ID 조회 성공", function () {
         client.assert(response.status === 200, "Expected 200 OK but got " + response.status);
+
         client.assert(response.body !== undefined, "response body 없음");
+        client.assert(response.body.success === true, "success 값이 true가 아님");
         client.assert(response.body.data !== undefined, "response.data 없음");
+
+        client.assert(response.body.data.ownerId !== undefined, "ownerId 없음");
         client.assert(response.body.data.restaurantId !== undefined, "restaurantId 없음");
+
+        client.assert(response.body.data.ownerId === client.variables.get("ownerId"),
+            "ownerId가 요청 ownerId와 다름");
     });
 
-    if (response.body && response.body.data && response.body.data.restaurantId) {
+    if (response.body && response.body.data) {
         client.global.set("restaurantId", response.body.data.restaurantId);
-        client.log("Saved restaurantId: " + response.body.data.restaurantId);
+        client.log("ownerId: " + response.body.data.ownerId);
+        client.log("restaurantId: " + response.body.data.restaurantId);
     }
 %}
 
-### 3. 점주 소유 식당 ID 조회 - 식당 없음
-@notFoundOwnerId = 99999999-9999-9999-9999-999999999999
 
+### 3. 점주 소유 식당 ID 조회 - 식당 없음
 GET {{restaurantServiceUrl}}/internal/v1/restaurants/owners/{{notFoundOwnerId}}/id
 X-Internal-Token: {{restaurantInternalToken}}
 Content-Type: application/json
@@ -51,12 +61,6 @@ Content-Type: application/json
 > {%
     client.test("점주 소유 식당이 없으면 404 응답", function () {
         client.assert(response.status === 404, "Expected 404 but got " + response.status);
-        client.assert(response.body !== undefined, "response body 없음");
-        client.assert(response.body.success === false, "success=false 여야 함");
-        client.assert(
-            response.body.code === "RESTAURANT_404_NOT_FOUND",
-            "Expected RESTAURANT_404_NOT_FOUND but got " + response.body.code
-        );
     });
 
     if (response.body) {

--- a/src/test/http/restaurant-internal.http
+++ b/src/test/http/restaurant-internal.http
@@ -59,8 +59,15 @@ X-Internal-Token: {{restaurantInternalToken}}
 Content-Type: application/json
 
 > {%
-    client.test("점주 소유 식당이 없으면 404 응답", function () {
+    client.test("점주 소유 식당이 없으면 RESTAURANT_404_NOT_FOUND 응답", function () {
         client.assert(response.status === 404, "Expected 404 but got " + response.status);
+
+        client.assert(response.body !== undefined, "response body 없음");
+        client.assert(response.body.success === false, "success=false 여야 함");
+        client.assert(
+            response.body.code === "RESTAURANT_404_NOT_FOUND",
+            "Expected RESTAURANT_404_NOT_FOUND but got " + response.body.code
+        );
     });
 
     if (response.body) {


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.

- 점주 소유 식당 식별 내부 API 응답에 `ownerId`를 추가
- 기존에는 `restaurantId`만 반환했지만, user-service의 회원 탈퇴 검증 및 order-service의 점주 커머스 주문 목록 조회에서 요청 기준 ownerId와 반환 restaurantId를 함께 확인할 수 있도록 응답 구조를 보완
- 기존 API 경로와 조회 정책은 유지
- ownerId 기준 활성 식당이 없으면 기존과 동일하게 `RESTAURANT_404_NOT_FOUND` 예외를 반환

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #42 
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to # 

## ✅ 자체 체크리스트 (필수)
- [ ] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [x] IntelliJ HTTP Client 테스트 완료 (인증샷 첨부)
- [ ] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [ ] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 IntelliJ HTTP Client 실행 화면을 여기에 첨부해 주세요.

<img width="1467" height="467" alt="스크린샷 2026-05-14 030239" src="https://github.com/user-attachments/assets/7d8f01d5-3fd7-4583-9d4d-5b35708ab1a5" />
<img width="1494" height="390" alt="스크린샷 2026-05-14 030256" src="https://github.com/user-attachments/assets/38de68ee-8491-4214-82ba-ab0141faf56c" />


## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.
> - [ ] 논의점
<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **기타**
  * 내부 API의 응답 구조를 개선하여 추가 정보를 포함하도록 업데이트했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Miche-Let/restaurant-service/pull/43)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->